### PR TITLE
Added SRG algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # ImageSegmentation
 
 Julia package for multiple Image Segmentation Algorithms
+
+## Project Status
+
+[![Build Status](https://travis-ci.org/JuliaImages/ImageSegmentation.jl.svg?branch=master)](https://travis-ci.org/JuliaImages/ImageSegmentation.jl)

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 julia 0.5
-Images 0.6
+Images 0.9
+DataStructures 0.5.3

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.5
 Images 0.9
 DataStructures 0.5.3
+FixedPointNumbers 0.3.0

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,3 @@
 julia 0.5
 Images 0.9
 DataStructures 0.5.3
-FixedPointNumbers 0.3.0

--- a/src/ImageSegmentation.jl
+++ b/src/ImageSegmentation.jl
@@ -8,8 +8,6 @@ include("region_growing.jl")
 
 export
     # methods
-    srg,
-    # types
-    Point
+    srg
 
 end # module

--- a/src/ImageSegmentation.jl
+++ b/src/ImageSegmentation.jl
@@ -6,10 +6,14 @@ using Images, DataStructures
 
 using FixedPointNumbers: floattype
 
+include("core.jl")
 include("region_growing.jl")
 
 export
     # methods
-    srg
+    seeded_region_growing,
+
+    # types
+    SegmentedImage
 
 end # module

--- a/src/ImageSegmentation.jl
+++ b/src/ImageSegmentation.jl
@@ -4,8 +4,6 @@ module ImageSegmentation
 
 using Images, DataStructures
 
-using FixedPointNumbers: floattype
-
 include("core.jl")
 include("region_growing.jl")
 

--- a/src/ImageSegmentation.jl
+++ b/src/ImageSegmentation.jl
@@ -4,6 +4,8 @@ module ImageSegmentation
 
 using Images, DataStructures
 
+using FixedPointNumbers: floattype
+
 include("region_growing.jl")
 
 export

--- a/src/ImageSegmentation.jl
+++ b/src/ImageSegmentation.jl
@@ -1,5 +1,15 @@
+__precompile__()
+
 module ImageSegmentation
 
-# package code goes here
+using Images, DataStructures
+
+include("region_growing.jl")
+
+export
+    # methods
+    srg,
+    # types
+    Point
 
 end # module

--- a/src/core.jl
+++ b/src/core.jl
@@ -1,5 +1,7 @@
-wrapping_type{CT<:Colorant}(::Type{CT}) = base_colorant_type(CT){FixedPointNumbers.floattype(eltype(CT))}
-
+"""
+`SegmentedImage` type contains the index-label mapping, assigned labels,
+segment mean intensity and pixel count of each segment.
+"""
 immutable SegmentedImage{T<:AbstractArray,U<:Colorant}
     img::T
     segment_labels::Vector{Int}

--- a/src/core.jl
+++ b/src/core.jl
@@ -1,0 +1,8 @@
+wrapping_type{CT<:Colorant}(::Type{CT}) = base_colorant_type(CT){FixedPointNumbers.floattype(eltype(CT))}
+
+immutable SegmentedImage{T<:AbstractArray,U<:Colorant}
+    img::T
+    segment_labels::Vector{Int}
+    segment_means::Dict{Int,U}
+    segment_pixel_count::Dict{Int,Int}
+end

--- a/src/core.jl
+++ b/src/core.jl
@@ -3,7 +3,7 @@
 segment mean intensity and pixel count of each segment.
 """
 immutable SegmentedImage{T<:AbstractArray,U<:Colorant}
-    img::T
+    image_indexmap::T
     segment_labels::Vector{Int}
     segment_means::Dict{Int,U}
     segment_pixel_count::Dict{Int,Int}

--- a/src/region_growing.jl
+++ b/src/region_growing.jl
@@ -1,0 +1,143 @@
+
+immutable Point
+    x::Int
+    y::Int
+end
+
+
+# An implementation of the Improved Seeded Region Growing Algorithm in Julia
+#
+# Citation:
+# Albert Mehnert, Paul Jackaway (1997), "An improved seeded region growing algorithm"
+# http://www.ee.bgu.ac.il/~itzik/IP5211/Other/Projects/P19_Seeded%20region%20growing.pdf
+
+function srg{CT<:Colorant}(img::AbstractArray{CT,2}, seeds::AbstractVector{Tuple{Point, Int}}, diff_fn::Function = (c1,c2)->(sum(abs,c1-c2)))
+
+    # Required data structures
+    result              =   similar(dims->fill(-1,dims), indices(img))  # Array to store labels
+    nhq                 =   Queue(Point)                                # Neighbours holding queue
+    pq                  =   PriorityQueue(Queue{Point}, Float64)        # Priority Queue to hold the queues of same δ value
+    qdict               =   Dict{Float64, Queue{Point}}()               # A map to get a reference to queue using the δ value
+    labelsq             =   Queue(Int)                                  # Queue to hold labels
+    holdingq            =   Queue(Point)                                # Queue to hold points corresponding to the labels in `labelsq`
+    region_means        =   Dict{Int, CT}()                             # A map containing (label, mean) pairs
+    region_pix_count    =   Dict{Int, Int}()                            # A map containing (label, pixel_count) pairs
+
+    # Labelling initial seeds and initialising `region_means` and `region_pix_count`
+    for seed in seeds
+        result[seed[1].y, seed[1].x] = seed[2]
+        region_pix_count[seed[2]] = get!(region_pix_count, seed[2], 0) + 1
+        region_means[seed[2]] = get!(region_means, seed[2], zero(CT)) * (1-1/region_pix_count[seed[2]]) + img[seed[1].y, seed[1].x]/(region_pix_count[seed[2]])
+    end
+
+    # Push an empty queue of priority Inf to store "Tied" points
+    q = Queue(Point)
+    enqueue!(pq, q, Inf)
+    qdict[Inf] = q
+
+    #=  Labeling scheme for the Array "result"-
+            Unlabelled => -1
+            In nhq => -2
+            In pq => -3
+            Tied => -4
+            Labelled => Seed value
+    =#
+
+    # Enqueue all the neighbours of seeds into `nhq`
+    for seed in seeds
+        for i in seed[1].x-1:seed[1].x+1, j in seed[1].y-1:seed[1].y+1
+            if (i,j) != (seed[1].x,seed[1].y) && checkbounds(Bool, img, j, i) && result[j,i] != -2
+                enqueue!(nhq, Point(i,j))
+                @inbounds result[j,i] = -2
+            end
+        end
+    end
+    
+    while !isempty(pq) || !isempty(nhq)
+        
+        while !isempty(nhq)
+            # For every neighbouring point, get the minimum δ
+            p = dequeue!(nhq)
+            δ = Inf
+            for i in p.x-1:p.x+1, j in p.y-1:p.y+1
+                if (i,j) != (p.x,p.y) && checkbounds(Bool, img, j, i) && result[j,i] >= 0
+                    curr_diff = diff_fn(region_means[result[j,i]], img[p.y, p.x])
+                    if δ > curr_diff
+                        δ = curr_diff
+                    end
+                end
+            end
+            if haskey(qdict, δ)
+                enqueue!(qdict[δ], p)
+            else
+                q = Queue(Point)
+                enqueue!(q, p)
+                enqueue!(pq, q, δ)
+                qdict[δ] = q
+            end
+            @inbounds result[p.y,p.x] = -3
+        end
+
+        # Get the queue with minimum δ from `pq` and add them to `holdingq` and their labels to `labelsq`
+        if !isempty(pq)
+            delete!(qdict, peek(pq)[2])
+            fq = dequeue!(pq)
+            while !isempty(fq)
+                p = dequeue!(fq)
+                if result[p.y, p.x] == -3 || result[p.y, p.x] == -4
+                    mindifflabel = -1
+                    mindiff = Inf
+                    istie = false
+                    for i in p.x-1:p.x+1, j in p.y-1:p.y+1
+                        if (i,j)!=(p.x,p.y) && checkbounds(Bool, img, j, i) && result[j,i] >= 0
+                            if mindifflabel < 0
+                                mindifflabel = result[j,i]
+                                mindiff = diff_fn(region_means[result[j,i]], img[p.y, p.x])
+                            elseif mindifflabel != result[j,i]
+                                curr_diff = diff_fn(region_means[result[j,i]], img[p.y, p.x])
+                                if curr_diff < mindiff
+                                    mindiff = curr_diff
+                                    mindifflabel = result[j,i]
+                                    istie = false
+                                else curr_diff == mindiff
+                                    istie = true
+                                end
+                            end
+                        end
+                    end
+                    if istie
+                        enqueue!(labelsq, -4)
+                        if result[p.y,p.x] != -4
+                            enqueue!(qdict[Inf], p)
+                        end
+                    else
+                        enqueue!(labelsq, mindifflabel)
+                    end
+                    enqueue!(holdingq, p)
+                    @inbounds result[p.y,p.x] = -2
+                end
+            end
+        end
+
+        # Add label to each point in `holdingq` and add their neighbours to `nhq`
+        while !isempty(holdingq)
+            label = dequeue!(labelsq)
+            p = dequeue!(holdingq)
+            result[p.y, p.x] = label
+            if label != -4
+                region_pix_count[label] += 1
+                region_means[label] = region_means[label]*(1-1/region_pix_count[label]) + img[p.y, p.x]/(region_pix_count[label])
+                for i in p.x-1:p.x+1, j in p.y-1:p.y+1
+                    if (i,j)!=(p.x,p.y) && checkbounds(Bool, img, j, i) && (result[j,i] == -1 || result[j,i] == -3)
+                        enqueue!(nhq, Point(i,j))
+                        @inbounds result[j,i] = -2
+                    end
+                end
+            end
+        end
+    
+    end
+    # The current output array contains a label for every point
+    # label can be a given "seed label" or "-4" if the point ties for two labels
+    result
+end

--- a/src/region_growing.jl
+++ b/src/region_growing.jl
@@ -1,27 +1,30 @@
 
+wrapping_type{CT<:Colorant}(::Type{CT}) = base_colorant_type(CT){FixedPointNumbers.floattype(eltype(CT))}
+
 # An implementation of the Improved Seeded Region Growing Algorithm in Julia
 #
 # Citation:
 # Albert Mehnert, Paul Jackaway (1997), "An improved seeded region growing algorithm"
 # http://www.ee.bgu.ac.il/~itzik/IP5211/Other/Projects/P19_Seeded%20region%20growing.pdf
 
-function srg{CT<:Colorant}(img::AbstractArray{CT,2}, seeds::AbstractVector{Tuple{CartesianIndex{2}, Int}}, diff_fn::Function = (c1,c2)->(sum(abs,c1-c2)))
+function srg{CT<:Colorant}(img::AbstractArray{CT,2}, seeds::AbstractVector{Tuple{CartesianIndex{2}, Int}}, diff_fn::Function = (c1,c2)->(sqrt(sum(abs2,wrapping_type(CT)(c1)-wrapping_type(CT)(c2)))))
+
 
     # Required data structures
-    result              =   similar(dims->fill(-1,dims), indices(img))  # Array to store labels
+    result              =   similar(dims->fill(-1,dims), indices(img))              # Array to store labels
     nhq                 =   Queue(CartesianIndex{2})                                # Neighbours holding queue
     pq                  =   PriorityQueue(Queue{CartesianIndex{2}}, Float64)        # Priority Queue to hold the queues of same δ value
     qdict               =   Dict{Float64, Queue{CartesianIndex{2}}}()               # A map to get a reference to queue using the δ value
-    labelsq             =   Queue(Int)                                  # Queue to hold labels
+    labelsq             =   Queue(Int)                                              # Queue to hold labels
     holdingq            =   Queue(CartesianIndex{2})                                # Queue to hold points corresponding to the labels in `labelsq`
-    region_means        =   Dict{Int, CT}()                             # A map containing (label, mean) pairs
-    region_pix_count    =   Dict{Int, Int}()                            # A map containing (label, pixel_count) pairs
+    region_means        =   Dict{Int, wrapping_type(CT)}()                          # A map containing (label, mean) pairs
+    region_pix_count    =   Dict{Int, Int}()                                        # A map containing (label, pixel_count) pairs
 
     # Labelling initial seeds and initialising `region_means` and `region_pix_count`
     for seed in seeds
         result[seed[1]] = seed[2]
         region_pix_count[seed[2]] = get!(region_pix_count, seed[2], 0) + 1
-        region_means[seed[2]] = get!(region_means, seed[2], zero(CT)) * (1-1/region_pix_count[seed[2]]) + img[seed[1]]/(region_pix_count[seed[2]])
+        region_means[seed[2]] = get!(region_means, seed[2], zero(wrapping_type(CT))) * (1-1/region_pix_count[seed[2]]) + img[seed[1]]/(region_pix_count[seed[2]])
     end
 
     # Push an empty queue of priority Inf to store "Tied" points
@@ -120,7 +123,8 @@ function srg{CT<:Colorant}(img::AbstractArray{CT,2}, seeds::AbstractVector{Tuple
             result[p] = label
             if label != -4
                 region_pix_count[label] += 1
-                region_means[label] = region_means[label]*(1-1/region_pix_count[label]) + img[p]/(region_pix_count[label])
+                region_means[label] *= (1-1/region_pix_count[label])
+                region_means[label] += img[p]/(region_pix_count[label])
                 for point in CartesianRange(p-1,p+1)
                     if point!=p && checkbounds(Bool, img, point) && (result[point] == -1 || result[point] == -3)
                         enqueue!(nhq, point)

--- a/src/region_growing.jl
+++ b/src/region_growing.jl
@@ -1,34 +1,52 @@
 
-wrapping_type{CT<:Colorant}(::Type{CT}) = base_colorant_type(CT){FixedPointNumbers.floattype(eltype(CT))}
-
 # An implementation of the Improved Seeded Region Growing Algorithm in Julia
 #
 # Citation:
 # Albert Mehnert, Paul Jackaway (1997), "An improved seeded region growing algorithm"
 # http://www.ee.bgu.ac.il/~itzik/IP5211/Other/Projects/P19_Seeded%20region%20growing.pdf
 
-function srg{CT<:Colorant}(img::AbstractArray{CT,2}, seeds::AbstractVector{Tuple{CartesianIndex{2}, Int}}, diff_fn::Function = (c1,c2)->(sqrt(sum(abs2,wrapping_type(CT)(c1)-wrapping_type(CT)(c2)))))
+function seeded_region_growing{CT<:Colorant, N}(img::AbstractArray{CT,N}, seeds::AbstractVector{Tuple{CartesianIndex{N},Int}},
+    kernel_dim::Vector{Int} = [3 for i in 1:N], diff_fn::Function = (c1,c2)->(sqrt(sum(abs2,wrapping_type(CT)(c1)-wrapping_type(CT)(c2)))))
+    length(kernel_dim) == N || error("Dimension count of image and kernel_dim do not match")
+    for dim in kernel_dim
+        dim > 0 || error("Dimensions of the kernel must be positive")
+        isodd(dim) || error("Dimensions of the kernel must be odd")
+    end
+    pt = CartesianIndex([floor(Int, dim/2) for dim in kernel_dim]...)
+    seeded_region_growing(img, seeds, ((c)->CartesianRange(c-pt,c+pt)), diff_fn)
+end
 
+function seeded_region_growing{CT<:Colorant, N}(img::AbstractArray{CT,N}, seeds::AbstractVector{Tuple{CartesianIndex{N},Int}},
+    neighbourhood::Function, diff_fn::Function = (c1,c2)->(sqrt(sum(abs2,wrapping_type(CT)(c1)-wrapping_type(CT)(c2)))))
+
+    # Check if labels are positive integers
+    for seed in seeds
+        seed[2] > 0 || error("Seed labels need to be positive integers!")
+    end
 
     # Required data structures
     result              =   similar(dims->fill(-1,dims), indices(img))              # Array to store labels
-    nhq                 =   Queue(CartesianIndex{2})                                # Neighbours holding queue
-    pq                  =   PriorityQueue(Queue{CartesianIndex{2}}, Float64)        # Priority Queue to hold the queues of same δ value
-    qdict               =   Dict{Float64, Queue{CartesianIndex{2}}}()               # A map to get a reference to queue using the δ value
+    nhq                 =   Queue(CartesianIndex{N})                                # Neighbours holding queue
+    pq                  =   PriorityQueue(Queue{CartesianIndex{N}}, Float64)        # Priority Queue to hold the queues of same δ value
+    qdict               =   Dict{Float64, Queue{CartesianIndex{N}}}()               # A map to get a reference to queue using the δ value
     labelsq             =   Queue(Int)                                              # Queue to hold labels
-    holdingq            =   Queue(CartesianIndex{2})                                # Queue to hold points corresponding to the labels in `labelsq`
+    holdingq            =   Queue(CartesianIndex{N})                                # Queue to hold points corresponding to the labels in `labelsq`
     region_means        =   Dict{Int, wrapping_type(CT)}()                          # A map containing (label, mean) pairs
     region_pix_count    =   Dict{Int, Int}()                                        # A map containing (label, pixel_count) pairs
+    labels              =   Vector{Int}()                                           # A vector containing list of labels
 
     # Labelling initial seeds and initialising `region_means` and `region_pix_count`
     for seed in seeds
         result[seed[1]] = seed[2]
         region_pix_count[seed[2]] = get!(region_pix_count, seed[2], 0) + 1
         region_means[seed[2]] = get!(region_means, seed[2], zero(wrapping_type(CT))) * (1-1/region_pix_count[seed[2]]) + img[seed[1]]/(region_pix_count[seed[2]])
+        if ! (seed[2] in labels)
+            push!(labels, seed[2])
+        end
     end
 
     # Push an empty queue of priority Inf to store "Tied" points
-    q = Queue(CartesianIndex{2})
+    q = Queue(CartesianIndex{N})
     enqueue!(pq, q, Inf)
     qdict[Inf] = q
 
@@ -36,13 +54,13 @@ function srg{CT<:Colorant}(img::AbstractArray{CT,2}, seeds::AbstractVector{Tuple
             Unlabelled => -1
             In nhq => -2
             In pq => -3
-            Tied => -4
+            Tied => 0
             Labelled => Seed value
     =#
 
     # Enqueue all the neighbours of seeds into `nhq`
     for seed in seeds
-        for point in CartesianRange(seed[1]-1, seed[1]+1)
+        for point in neighbourhood(seed[1])
             if point != seed[1] && checkbounds(Bool, img, point) && result[point] != -2
                 enqueue!(nhq, point)
                 @inbounds result[point] = -2
@@ -56,8 +74,8 @@ function srg{CT<:Colorant}(img::AbstractArray{CT,2}, seeds::AbstractVector{Tuple
             # For every neighbouring point, get the minimum δ
             p = dequeue!(nhq)
             δ = Inf
-            for point in CartesianRange(p-1,p+1)
-                if point != p && checkbounds(Bool, img, point) && result[point] >= 0
+            for point in neighbourhood(p)
+                if point != p && checkbounds(Bool, img, point) && result[point] > 0
                     curr_diff = diff_fn(region_means[result[point]], img[p])
                     if δ > curr_diff
                         δ = curr_diff
@@ -67,7 +85,7 @@ function srg{CT<:Colorant}(img::AbstractArray{CT,2}, seeds::AbstractVector{Tuple
             if haskey(qdict, δ)
                 enqueue!(qdict[δ], p)
             else
-                q = Queue(CartesianIndex{2})
+                q = Queue(CartesianIndex{N})
                 enqueue!(q, p)
                 enqueue!(pq, q, δ)
                 qdict[δ] = q
@@ -81,12 +99,12 @@ function srg{CT<:Colorant}(img::AbstractArray{CT,2}, seeds::AbstractVector{Tuple
             fq = dequeue!(pq)                                   # fq is the front queue of priority queue `pq` i.e. queue having minimum δ
             while !isempty(fq)
                 p = dequeue!(fq)
-                if result[p] == -3 || result[p] == -4
+                if result[p] == -3 || result[p] == 0
                     mindifflabel = -1
                     mindiff = Inf
                     istie = false
-                    for point in CartesianRange(p-1,p+1)
-                        if point!=p && checkbounds(Bool, img, point) && result[point] >= 0
+                    for point in neighbourhood(p)
+                        if point!=p && checkbounds(Bool, img, point) && result[point] > 0
                             if mindifflabel < 0
                                 mindifflabel = result[point]
                                 mindiff = diff_fn(region_means[result[point]], img[p])
@@ -103,8 +121,8 @@ function srg{CT<:Colorant}(img::AbstractArray{CT,2}, seeds::AbstractVector{Tuple
                         end
                     end
                     if istie
-                        enqueue!(labelsq, -4)
-                        if result[p] != -4
+                        enqueue!(labelsq, 0)
+                        if result[p] != 0
                             enqueue!(qdict[Inf], p)
                         end
                     else
@@ -121,11 +139,11 @@ function srg{CT<:Colorant}(img::AbstractArray{CT,2}, seeds::AbstractVector{Tuple
             label = dequeue!(labelsq)
             p = dequeue!(holdingq)
             result[p] = label
-            if label != -4
+            if label != 0
                 region_pix_count[label] += 1
                 region_means[label] *= (1-1/region_pix_count[label])
                 region_means[label] += img[p]/(region_pix_count[label])
-                for point in CartesianRange(p-1,p+1)
+                for point in neighbourhood(p)
                     if point!=p && checkbounds(Bool, img, point) && (result[point] == -1 || result[point] == -3)
                         enqueue!(nhq, point)
                         @inbounds result[point] = -2
@@ -135,7 +153,11 @@ function srg{CT<:Colorant}(img::AbstractArray{CT,2}, seeds::AbstractVector{Tuple
         end
     
     end
-    # The current output array contains a label for every point
-    # label can be a given "seed label" or "-4" if the point ties for two labels
-    result
+    
+    c0 = count(i->(i==0),result)
+    if c0 != 0
+        push!(labels, 0)
+        region_pix_count[0] = c0
+    end
+    SegmentedImage(result, labels, region_means, region_pix_count)
 end

--- a/src/region_growing.jl
+++ b/src/region_growing.jl
@@ -13,13 +13,13 @@ and returns a [`SegmentedImage`](@ref) containing information about the segments
 * `seeds`           :  `Vector` containing seeds. Each seed is a Tuple of a
                        CartesianIndex{N} and a label. See below note for more
                        information on labels.
-* `kernel_dim`      :  (Optional) `Vector{Int}` having length N whose ith element
-                       is an odd positive integer representing the length of the
-                       ith edge of the N-orthotopic neighbourhood
+* `kernel_dim`      :  (Optional) `Vector{Int}` having length N or a `NTuple{N,Int}`
+                       whose ith element is an odd positive integer representing
+                       the length of the ith edge of the N-orthotopic neighbourhood
 * `neighbourhood`   :  (Optional) Function taking CartesianIndex{N} as input and
                        returning the neighbourhood of that point.
 * `diff_fn`         :  (Optional) Function that returns a difference measure(δ)
-                       between a region mean and a point
+                       between the mean color of a region and color of a point
 
 !!! note
     The labels attached to points must be positive integers, although multiple
@@ -50,7 +50,7 @@ Albert Mehnert, Paul Jackaway (1997), "An improved seeded region growing algorit
 Pattern Recognition Letters 18 (1997), 1065-1071
 """
 function seeded_region_growing{CT<:Colorant, N}(img::AbstractArray{CT,N}, seeds::AbstractVector{Tuple{CartesianIndex{N},Int}},
-    kernel_dim::Vector{Int} = [3 for i in 1:N], diff_fn::Function = default_diff_fn)
+    kernel_dim::Union{Vector{Int}, NTuple{N, Int}} = [3 for i in 1:N], diff_fn::Function = default_diff_fn)
     length(kernel_dim) == N || error("Dimension count of image and kernel_dim do not match")
     for dim in kernel_dim
         dim > 0 || error("Dimensions of the kernel must be positive")

--- a/test/region_growing.jl
+++ b/test/region_growing.jl
@@ -1,0 +1,128 @@
+get_wrapped{CT<:Colorant}(p::CT) = Images.accum(typeof(p))(p)
+
+@testset "Seeded Region Growing" begin
+    # 2-D image
+    img = zeros(Gray{N0f8}, 10, 10)
+    img[6:10,4:8] = 0.5
+    img[3:7,2:6] = 0.8
+    seeds = [(CartesianIndex(3,9),1), (CartesianIndex(5,2),2), (CartesianIndex(9,7),3)]
+
+    expected = ones(Int, 10, 10)
+    expected[6:10,4:8] = 3
+    expected[3:7,2:6] = 2
+    expected_labels = [1,2,3]
+    expected_means = Dict(1 => get_wrapped(img[3,9]), 2 => get_wrapped(img[5,2]), 3 => get_wrapped(img[9,7]))
+    expected_count = Dict(1 => 56, 2 => 25, 3 => 19)
+
+    seg = seeded_region_growing(img, seeds)
+    @test all(label->(label in expected_labels), seg.segment_labels)
+    @test all(label->(label in seg.segment_labels), expected_labels)
+    @test expected_count == seg.segment_pixel_count
+    @test expected_means == seg.segment_means
+    @test seg.img == expected
+
+    # Custom neighbourhood using a function
+    seg = seeded_region_growing(img, seeds, c->[CartesianIndex(c[1]-1,c[2]), CartesianIndex(c[1]+1,c[2]), CartesianIndex(c[1],c[2]-1), CartesianIndex(c[1],c[2]+1)])
+    @test all(label->(label in expected_labels), seg.segment_labels)
+    @test all(label->(label in seg.segment_labels), expected_labels)
+    @test expected_count == seg.segment_pixel_count
+    @test expected_means == seg.segment_means
+    @test seg.img == expected
+
+    # Offset image
+    img = centered(img)
+    seeds = [(CartesianIndex(-2,4),1), (CartesianIndex(0,-3),2), (CartesianIndex(4,2),3)]
+    expected = centered(expected)
+    seg = seeded_region_growing(img, seeds)
+    @test all(label->(label in expected_labels), seg.segment_labels)
+    @test all(label->(label in seg.segment_labels), expected_labels)
+    @test expected_count == seg.segment_pixel_count
+    @test expected_means == seg.segment_means
+    @test seg.img == expected
+
+    # Custom neighbourhood using a [3,3] vs [5,5] kernel
+    img = zeros(Gray{N0f8}, 5, 5)
+    img[2:4,2:4] = 1
+    img[3,3] = 0
+    seeds = [(CartesianIndex(3,3),1), (CartesianIndex(2,3),2)]
+
+    expected = fill(2,(5,5))
+    expected[3,3] = 1
+    expected_labels = [1,2]
+    expected_means = Dict(1=>Gray{Float64}(0.0), 2=>Gray{Float64}(1/3))
+    expected_count = Dict(1=>1, 2=>24)
+
+    seg = seeded_region_growing(img, seeds, [3,3])
+    @test all(label->(label in expected_labels), seg.segment_labels)
+    @test all(label->(label in seg.segment_labels), expected_labels)
+    @test expected_count == seg.segment_pixel_count
+    @test all(label->(expected_means[label] ≈ seg.segment_means[label]), seg.segment_labels)
+    @test seg.img == expected
+
+    expected = ones(Int, 5, 5)
+    expected[2:4,2:4] = 2
+    expected[3,3] = 1
+    expected_labels = [1,2]
+    expected_means = Dict(1=>Gray{N0f8}(0.0), 2=>Gray{N0f8}(1.0))
+    expected_count = Dict(1=>17, 2=>8)
+
+    seg = seeded_region_growing(img, seeds, [5,5])
+    @test all(label->(label in expected_labels), seg.segment_labels)
+    @test all(label->(label in seg.segment_labels), expected_labels)
+    @test expected_count == seg.segment_pixel_count
+    @test expected_means == seg.segment_means
+    @test seg.img == expected
+
+    # 3-d image
+    img = zeros(RGB{N0f8},(9,9,9))
+    img[3:7,3:7,3:7] = RGB{N0f8}(0.5,0.5,0.5)
+    img[2:5,5:9,4:6] = RGB{N0f8}(0.8,0.8,0.8)
+    seeds = [(CartesianIndex(1,1,1),1), (CartesianIndex(6,4,4),2), (CartesianIndex(3,6,5),3)]
+
+    expected = ones(Int, (9,9,9))
+    expected[3:7,3:7,3:7] = 2
+    expected[2:5,5:9,4:6] = 3
+    expected_labels = [1,2,3]
+    expected_means = Dict([(i, get_wrapped(img[seeds[i][1]])) for i in 1:3])
+    expected_count = Dict(1=>571, 2=>98, 3=>60)
+
+    seg = seeded_region_growing(img, seeds)
+    @test all(label->(label in expected_labels), seg.segment_labels)
+    @test all(label->(label in seg.segment_labels), expected_labels)
+    @test expected_count == seg.segment_pixel_count
+    @test expected_means == seg.segment_means
+    @test seg.img == expected
+
+    # custom diff_fn
+    img = zeros(RGB{N0f8},(3,3))
+    img[1:3,1] = RGB{N0f8}(0.4,1,0)
+    img[1:3,2] = RGB{N0f8}(0.2,1,0)
+    seeds = [(CartesianIndex(2,1),1), (CartesianIndex(2,3),2)]
+
+    expected = ones(Int, (3,3))
+    expected[1:3,3] = 2
+    expected_labels = [1,2]
+    expected_means = Dict(1=>RGB{Float64}(0.3,1.0,0.0), 2=>RGB{Float64}(0.0,0.0,0.0))
+    expected_count = Dict(1=>6, 2=>3)
+
+    seg = seeded_region_growing(img, seeds)
+    @test all(label->(label in expected_labels), seg.segment_labels)
+    @test all(label->(label in seg.segment_labels), expected_labels)
+    @test expected_count == seg.segment_pixel_count
+    @test expected_means == seg.segment_means
+    @test seg.img == expected
+
+    expected = ones(Int, (3,3))
+    expected[1:3,2] = 0
+    expected[1:3,3] = 2
+    expected_labels = [0,1,2]
+    expected_means = Dict(1=>RGB{Float64}(0.4,1.0,0.0), 2=>RGB{Float64}(0.0,0.0,0.0))
+    expected_count = Dict(0=>3, 1=>3, 2=>3)
+
+    seg = seeded_region_growing(img, seeds, [3,3], (c1,c2)->abs(get_wrapped(c1).r - get_wrapped(c2).r))
+    @test all(label->(label in expected_labels), seg.segment_labels)
+    @test all(label->(label in seg.segment_labels), expected_labels)
+    @test expected_count == seg.segment_pixel_count
+    @test expected_means == seg.segment_means
+    @test seg.img == expected
+end

--- a/test/region_growing.jl
+++ b/test/region_growing.jl
@@ -19,7 +19,7 @@ of_accum_type(p::Colorant) = Images.accum(typeof(p))(p)
     @test all(label->(label in seg.segment_labels), expected_labels)
     @test expected_count == seg.segment_pixel_count
     @test expected_means == seg.segment_means
-    @test seg.img == expected
+    @test seg.image_indexmap == expected
 
     # Custom neighbourhood using a function
     seg = seeded_region_growing(img, seeds, c->[CartesianIndex(c[1]-1,c[2]), CartesianIndex(c[1]+1,c[2]), CartesianIndex(c[1],c[2]-1), CartesianIndex(c[1],c[2]+1)])
@@ -27,7 +27,7 @@ of_accum_type(p::Colorant) = Images.accum(typeof(p))(p)
     @test all(label->(label in seg.segment_labels), expected_labels)
     @test expected_count == seg.segment_pixel_count
     @test expected_means == seg.segment_means
-    @test seg.img == expected
+    @test seg.image_indexmap == expected
 
     # Offset image
     img = centered(img)
@@ -38,7 +38,7 @@ of_accum_type(p::Colorant) = Images.accum(typeof(p))(p)
     @test all(label->(label in seg.segment_labels), expected_labels)
     @test expected_count == seg.segment_pixel_count
     @test expected_means == seg.segment_means
-    @test seg.img == expected
+    @test seg.image_indexmap == expected
 
     # Custom neighbourhood using a [3,3] vs [5,5] kernel
     img = zeros(Gray{N0f8}, 5, 5)
@@ -57,7 +57,7 @@ of_accum_type(p::Colorant) = Images.accum(typeof(p))(p)
     @test all(label->(label in seg.segment_labels), expected_labels)
     @test expected_count == seg.segment_pixel_count
     @test all(label->(expected_means[label] ≈ seg.segment_means[label]), seg.segment_labels)
-    @test seg.img == expected
+    @test seg.image_indexmap == expected
 
     expected = ones(Int, 5, 5)
     expected[2:4,2:4] = 2
@@ -71,7 +71,7 @@ of_accum_type(p::Colorant) = Images.accum(typeof(p))(p)
     @test all(label->(label in seg.segment_labels), expected_labels)
     @test expected_count == seg.segment_pixel_count
     @test expected_means == seg.segment_means
-    @test seg.img == expected
+    @test seg.image_indexmap == expected
 
     # 3-d image
     img = zeros(RGB{N0f8},(9,9,9))
@@ -91,7 +91,7 @@ of_accum_type(p::Colorant) = Images.accum(typeof(p))(p)
     @test all(label->(label in seg.segment_labels), expected_labels)
     @test expected_count == seg.segment_pixel_count
     @test expected_means == seg.segment_means
-    @test seg.img == expected
+    @test seg.image_indexmap == expected
 
     # custom diff_fn
     img = zeros(RGB{N0f8},(3,3))
@@ -110,7 +110,7 @@ of_accum_type(p::Colorant) = Images.accum(typeof(p))(p)
     @test all(label->(label in seg.segment_labels), expected_labels)
     @test expected_count == seg.segment_pixel_count
     @test expected_means == seg.segment_means
-    @test seg.img == expected
+    @test seg.image_indexmap == expected
 
     expected = ones(Int, (3,3))
     expected[1:3,2] = 0
@@ -124,5 +124,5 @@ of_accum_type(p::Colorant) = Images.accum(typeof(p))(p)
     @test all(label->(label in seg.segment_labels), expected_labels)
     @test expected_count == seg.segment_pixel_count
     @test expected_means == seg.segment_means
-    @test seg.img == expected
+    @test seg.image_indexmap == expected
 end

--- a/test/region_growing.jl
+++ b/test/region_growing.jl
@@ -1,4 +1,4 @@
-get_wrapped{CT<:Colorant}(p::CT) = Images.accum(typeof(p))(p)
+of_accum_type(p::Colorant) = Images.accum(typeof(p))(p)
 
 @testset "Seeded Region Growing" begin
     # 2-D image
@@ -11,7 +11,7 @@ get_wrapped{CT<:Colorant}(p::CT) = Images.accum(typeof(p))(p)
     expected[6:10,4:8] = 3
     expected[3:7,2:6] = 2
     expected_labels = [1,2,3]
-    expected_means = Dict(1 => get_wrapped(img[3,9]), 2 => get_wrapped(img[5,2]), 3 => get_wrapped(img[9,7]))
+    expected_means = Dict(1 => of_accum_type(img[3,9]), 2 => of_accum_type(img[5,2]), 3 => of_accum_type(img[9,7]))
     expected_count = Dict(1 => 56, 2 => 25, 3 => 19)
 
     seg = seeded_region_growing(img, seeds)
@@ -52,7 +52,7 @@ get_wrapped{CT<:Colorant}(p::CT) = Images.accum(typeof(p))(p)
     expected_means = Dict(1=>Gray{Float64}(0.0), 2=>Gray{Float64}(1/3))
     expected_count = Dict(1=>1, 2=>24)
 
-    seg = seeded_region_growing(img, seeds, [3,3])
+    seg = seeded_region_growing(img, seeds, (3,3))
     @test all(label->(label in expected_labels), seg.segment_labels)
     @test all(label->(label in seg.segment_labels), expected_labels)
     @test expected_count == seg.segment_pixel_count
@@ -66,7 +66,7 @@ get_wrapped{CT<:Colorant}(p::CT) = Images.accum(typeof(p))(p)
     expected_means = Dict(1=>Gray{N0f8}(0.0), 2=>Gray{N0f8}(1.0))
     expected_count = Dict(1=>17, 2=>8)
 
-    seg = seeded_region_growing(img, seeds, [5,5])
+    seg = seeded_region_growing(img, seeds, (5,5))
     @test all(label->(label in expected_labels), seg.segment_labels)
     @test all(label->(label in seg.segment_labels), expected_labels)
     @test expected_count == seg.segment_pixel_count
@@ -83,7 +83,7 @@ get_wrapped{CT<:Colorant}(p::CT) = Images.accum(typeof(p))(p)
     expected[3:7,3:7,3:7] = 2
     expected[2:5,5:9,4:6] = 3
     expected_labels = [1,2,3]
-    expected_means = Dict([(i, get_wrapped(img[seeds[i][1]])) for i in 1:3])
+    expected_means = Dict([(i, of_accum_type(img[seeds[i][1]])) for i in 1:3])
     expected_count = Dict(1=>571, 2=>98, 3=>60)
 
     seg = seeded_region_growing(img, seeds)
@@ -119,7 +119,7 @@ get_wrapped{CT<:Colorant}(p::CT) = Images.accum(typeof(p))(p)
     expected_means = Dict(1=>RGB{Float64}(0.4,1.0,0.0), 2=>RGB{Float64}(0.0,0.0,0.0))
     expected_count = Dict(0=>3, 1=>3, 2=>3)
 
-    seg = seeded_region_growing(img, seeds, [3,3], (c1,c2)->abs(get_wrapped(c1).r - get_wrapped(c2).r))
+    seg = seeded_region_growing(img, seeds, [3,3], (c1,c2)->abs(of_accum_type(c1).r - of_accum_type(c2).r))
     @test all(label->(label in expected_labels), seg.segment_labels)
     @test all(label->(label in seg.segment_labels), expected_labels)
     @test expected_count == seg.segment_pixel_count

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,3 @@
-using ImageSegmentation
-using Base.Test
+using ImageSegmentation, Images, Base.Test
 
-# write your own tests here
-@test 1 == 2
+include("region_growing.jl")


### PR DESCRIPTION
An Implementation of the Seeded Region Growing Algorithm (Improved version) as explained in [this paper](http://www.ee.bgu.ac.il/~itzik/IP5211/Other/Projects/P19_Seeded%20region%20growing.pdf). It can currently be used with various color models (like `RGB`, `RGBA`, `GrayA` etc) and also works with arrays having custom indices (like `OffsetArrays`). Multiple points can be given the same label to indicate that they belong to the same region. The `srg` function can be used as: 
```julia
img_seg = srg(img, seeds, diff_fn)
```
Here,
`img` is the input image
`seeds` is a vector of `Tuple{CartesianIndex{2}, Int}`. Each seed corresponds to a point on the image along with a label (which is of type `Int`). This label is used to identify a region uniquely in the segmented image.
`diff_fn` is a function to calculate δ between a region and a neighboring point.

Currently, the output is an array having indices similar to that of the input image. Each point of this array contains a label corresponding to the region to which it belongs. The label can be any of the seed labels or a special value (-4) that corresponds to a point that has same δ value for two (or more) neighbors (boundary tied points).

An example:
```julia
using Images, ImageSegmentation, ImageView

img = load("img.jpg")
img = centered(img)
imshow(img)
seeds = [(CartesianIndex(-54,-14),1), (CartesianIndex(66,-14), 2), (CartesianIndex(1,77), 3), (CartesianIndex(85,-83),4), (CartesianIndex(-79,96), 4)]
img_s = srg(img, seeds)
imshow(map(i->((i==3)?RGB(0,1,0):(i==2)?RGB(0,0,0):(i==1)?RGB(1,0,0):RGB(1,1,1)), img_s))
```
Original:
![org](https://cloud.githubusercontent.com/assets/15063205/26763215/b3bf8e82-496c-11e7-9499-a4c196747370.png)

After segmentation (before changes):
![seg](https://cloud.githubusercontent.com/assets/15063205/26763233/e4187b02-496c-11e7-828a-ace4f4230272.png)

After segmentation (after changes):
![seg](https://cloud.githubusercontent.com/assets/15063205/26801300/1330cb7c-4a5a-11e7-99ad-5585b013f430.png)




There are a few things which need to be discussed:
- We could give the user more control by adding some more features like custom neighborhood (which would default to 8-connectivity) and unrestricted labels (which would mean labels could be `String`, `Float` or anything else)
- The algorithm is restricted to 2-dimensional arrays but can be modified to be used with general N-dimensional arrays.
- Currently, the output is an array containing seed labels for segmented regions and a special value (-4) for tied points. This needs to changed as the user can provide (-4) as a seed label. I was thinking of a new return type
```julia
type SegmentedImage{T<:AbstractArray,U}
    img::T
    segment_labels::Vector{U}
    segment_means::Dict{U,eltype(T)}
    segment_pixel_count::Dict{U,Int}
end
```
where, `img::T` is the `result` array that we get as output now. We can label the tied boundary points as `-Inf` or something like that.

Once we settle for an API, the documentation and tests could be added.