### PR TITLE
Added URG algorithm

### DIFF
--- a/src/ImageSegmentation.jl
+++ b/src/ImageSegmentation.jl
@@ -10,7 +10,8 @@ include("region_growing.jl")
 export
     # methods
     seeded_region_growing,
-
+    unseeded_region_growing,
+    
     # types
     SegmentedImage
 

--- a/src/region_growing.jl
+++ b/src/region_growing.jl
@@ -284,9 +284,10 @@ function unseeded_region_growing{CT<:Colorant,N}(img::AbstractArray{CT,N}, thres
         point = dequeue!(neighbours)
         δ = Inf
         minlabel = -1
+        pixelval = img[point]
         for p in neighbourhood(point)
             if p != point && checkbounds(Bool, img, p) && result[p] > 0
-                curδ = diff_fn(region_means[result[p]], img[point])
+                curδ = diff_fn(region_means[result[p]], pixelval)
                 if curδ < δ
                     δ = curδ
                     minlabel = result[p]
@@ -302,7 +303,7 @@ function unseeded_region_growing{CT<:Colorant,N}(img::AbstractArray{CT,N}, thres
             δ = Inf
             minlabel = -1
             for label in labels
-                curδ = diff_fn(region_means[label], img[point])
+                curδ = diff_fn(region_means[label], pixelval)
                 if curδ < δ
                     δ = curδ
                     minlabel = label
@@ -321,7 +322,7 @@ function unseeded_region_growing{CT<:Colorant,N}(img::AbstractArray{CT,N}, thres
 
         #Update region_means
         region_pix_count[minlabel] = get(region_pix_count, minlabel, 0) + 1
-        region_means[minlabel] = get(region_means, minlabel, zero(Images.accum(CT))) + (img[point] - get(region_means, minlabel, zero(Images.accum(CT))))/(region_pix_count[minlabel])
+        region_means[minlabel] = get(region_means, minlabel, zero(Images.accum(CT))) + (pixelval - get(region_means, minlabel, zero(Images.accum(CT))))/(region_pix_count[minlabel])
 
         # Enqueue neighbours of `point`
         for p in neighbourhood(point)

--- a/src/region_growing.jl
+++ b/src/region_growing.jl
@@ -49,15 +49,17 @@ julia> seg.image_indexmap
 Albert Mehnert, Paul Jackaway (1997), "An improved seeded region growing algorithm",
 Pattern Recognition Letters 18 (1997), 1065-1071
 """
+
 function seeded_region_growing{CT<:Colorant, N}(img::AbstractArray{CT,N}, seeds::AbstractVector{Tuple{CartesianIndex{N},Int}},
-    kernel_dim::Union{Vector{Int}, NTuple{N, Int}} = [3 for i in 1:N], diff_fn::Function = default_diff_fn)
+    kernel_dim::Union{Vector{Int}, NTuple{N, Int}} = ntuple(i->3,N), diff_fn::Function = default_diff_fn)
     length(kernel_dim) == N || error("Dimension count of image and kernel_dim do not match")
     for dim in kernel_dim
         dim > 0 || error("Dimensions of the kernel must be positive")
         isodd(dim) || error("Dimensions of the kernel must be odd")
     end
-    pt = CartesianIndex([dim ÷ 2 for dim in kernel_dim]...)
-    seeded_region_growing(img, seeds, ((c)->CartesianRange(c-pt,c+pt)), diff_fn)
+    pt = CartesianIndex(ntuple(i->kernel_dim[i]÷2, N))
+    neighbourhood_gen(t) = c->CartesianRange(c-t,c+t)
+    seeded_region_growing(img, seeds, neighbourhood_gen(pt), diff_fn)
 end
 
 function seeded_region_growing{CT<:Colorant, N}(img::AbstractArray{CT,N}, seeds::AbstractVector{Tuple{CartesianIndex{N},Int}},
@@ -244,14 +246,15 @@ julia> seg.image_indexmap
 
 """
 function unseeded_region_growing{CT<:Colorant, N}(img::AbstractArray{CT,N}, threshold::Real,
-    kernel_dim::Union{Vector{Int}, NTuple{N, Int}} = [3 for i in 1:N], diff_fn::Function = default_diff_fn)
+    kernel_dim::Union{Vector{Int}, NTuple{N, Int}} = ntuple(i->3,N), diff_fn::Function = default_diff_fn)
     length(kernel_dim) == N || error("Dimension count of image and kernel_dim do not match")
     for dim in kernel_dim
         dim > 0 || error("Dimensions of the kernel must be positive")
         isodd(dim) || error("Dimensions of the kernel must be odd")
     end
-    pt = CartesianIndex([dim ÷ 2 for dim in kernel_dim]...)
-    unseeded_region_growing(img, threshold, ((c)->CartesianRange(c-pt,c+pt)), diff_fn)
+    pt = CartesianIndex(ntuple(i->kernel_dim[i]÷2, N))
+    neighbourhood_gen(t) = c->CartesianRange(c-t,c+t)
+    unseeded_region_growing(img, threshold, neighbourhood_gen(pt), diff_fn)
 end
 
 function unseeded_region_growing{CT<:Colorant,N}(img::AbstractArray{CT,N}, threshold::Real, neighbourhood::Function, diff_fn = default_diff_fn)

--- a/src/region_growing.jl
+++ b/src/region_growing.jl
@@ -35,7 +35,7 @@ julia> img = zeros(Gray{N0f8},4,4);
 julia> img[2:4,2:4] = 1;
 julia> seeds = [(CartesianIndex(3,1),1),(CartesianIndex(2,2),2)];
 julia> seg = seeded_region_growing(img, seeds);
-julia> seg.img
+julia> seg.image_indexmap
 4×4 Array{Int64,2}:
  1  1  1  1
  1  2  2  2
@@ -84,8 +84,8 @@ function seeded_region_growing{CT<:Colorant, N}(img::AbstractArray{CT,N}, seeds:
     # Labelling initial seeds and initialising `region_means` and `region_pix_count`
     for seed in seeds
         result[seed[1]] = seed[2]
-        region_pix_count[seed[2]] = get!(region_pix_count, seed[2], 0) + 1
-        region_means[seed[2]] = get!(region_means, seed[2], zero(Images.accum(CT))) + (img[seed[1]] - get!(region_means, seed[2], zero(Images.accum(CT))))/(region_pix_count[seed[2]])
+        region_pix_count[seed[2]] = get(region_pix_count, seed[2], 0) + 1
+        region_means[seed[2]] = get(region_means, seed[2], zero(Images.accum(CT))) + (img[seed[1]] - get(region_means, seed[2], zero(Images.accum(CT))))/(region_pix_count[seed[2]])
         if ! (seed[2] in labels)
             push!(labels, seed[2])
         end
@@ -203,6 +203,139 @@ function seeded_region_growing{CT<:Colorant, N}(img::AbstractArray{CT,N}, seeds:
     if c0 != 0
         push!(labels, 0)
         region_pix_count[0] = c0
+    end
+    SegmentedImage(result, labels, region_means, region_pix_count)
+end
+
+
+"""
+    seg_img = unseeded_region_growing(img, threshold, [kernel_dim], [diff_fn])
+    seg_img = unseeded_region_growing(img, threshold, [neighbourhood], [diff_fn])
+
+Segments the N-D image using automatic (unseeded) region growing algorithm
+and returns a [`SegmentedImage`](@ref) containing information about the segments.
+
+# Arguments:
+* `img`             :  N-D image to be segmented (arbitrary indices are allowed)
+* `threshold`       :  Upper bound of the difference measure (δ) for considering
+                       pixel into same segment
+* `kernel_dim`      :  (Optional) `Vector{Int}` having length N or a `NTuple{N,Int}`
+                       whose ith element is an odd positive integer representing
+                       the length of the ith edge of the N-orthotopic neighbourhood
+* `neighbourhood`   :  (Optional) Function taking CartesianIndex{N} as input and
+                       returning the neighbourhood of that point.
+* `diff_fn`         :  (Optional) Function that returns a difference measure (δ)
+                       between the mean color of a region and color of a point
+
+# Examples
+
+```jldoctest
+julia> img = zeros(Gray{N0f8},4,4);
+julia> img[2:4,2:4] = 1;
+julia> seg = unseeded_region_growing(img, 0.2);
+julia> seg.image_indexmap
+4×4 Array{Int64,2}:
+ 1  1  1  1
+ 1  2  2  2
+ 1  2  2  2
+ 1  2  2  2
+
+```
+
+"""
+function unseeded_region_growing{CT<:Colorant, N}(img::AbstractArray{CT,N}, threshold::Real,
+    kernel_dim::Union{Vector{Int}, NTuple{N, Int}} = [3 for i in 1:N], diff_fn::Function = default_diff_fn)
+    length(kernel_dim) == N || error("Dimension count of image and kernel_dim do not match")
+    for dim in kernel_dim
+        dim > 0 || error("Dimensions of the kernel must be positive")
+        isodd(dim) || error("Dimensions of the kernel must be odd")
+    end
+    pt = CartesianIndex([dim ÷ 2 for dim in kernel_dim]...)
+    unseeded_region_growing(img, threshold, ((c)->CartesianRange(c-pt,c+pt)), diff_fn)
+end
+
+function unseeded_region_growing{CT<:Colorant,N}(img::AbstractArray{CT,N}, threshold::Real, neighbourhood::Function, diff_fn = default_diff_fn)
+   
+    # Required data structures 
+    result                  =   similar(dims->fill(-1,dims), indices(img))      # Array to store labels
+    neighbours              =   PriorityQueue(CartesianIndex{N}, Float64)       # Priority Queue containing boundary pixels with δ as the priority
+    region_means            =   Dict{Int, Images.accum(CT)}()                   # A map containing (label, mean) pairs
+    region_pix_count        =   Dict{Int, Int}()                                # A map containing (label, pixel_count) pairs
+    labels                  =   Vector{Int}()                                   # Vector containing assigned labels
+
+    # Initialize data structures
+    start_point = first(CartesianRange(indices(img)))
+    result[start_point] = 1
+    push!(labels, 1)
+    region_means[1] = img[start_point]
+    region_pix_count[1] = 1
+
+    # Enqueue neighouring points of `start_point`
+    for p in neighbourhood(start_point)
+        if p != start_point && checkbounds(Bool, img, p) && result[p] == -1
+            enqueue!(neighbours, p, diff_fn(region_means[result[start_point]], img[p]))
+        end
+    end
+    
+    while !isempty(neighbours)
+        point = dequeue!(neighbours)
+        δ = Inf
+        minlabel = -1
+        for p in neighbourhood(point)
+            if p != point && checkbounds(Bool, img, p) && result[p] > 0
+                curδ = diff_fn(region_means[result[p]], img[point])
+                if curδ < δ
+                    δ = curδ
+                    minlabel = result[p]
+                end
+            end
+        end
+
+        if δ < threshold
+            # Assign point to minlabel
+            result[point] = minlabel
+        else
+            # Select most appropriate label
+            δ = Inf
+            minlabel = -1
+            for label in labels
+                curδ = diff_fn(region_means[label], img[point])
+                if curδ < δ
+                    δ = curδ
+                    minlabel = label
+                end
+            end
+
+            if δ < threshold
+                result[point] = minlabel
+            else
+                # Assign point to a new label
+                minlabel = length(labels) + 1
+                push!(labels, minlabel)
+                result[point] = minlabel
+            end
+        end
+
+        #Update region_means
+        region_pix_count[minlabel] = get(region_pix_count, minlabel, 0) + 1
+        region_means[minlabel] = get(region_means, minlabel, zero(Images.accum(CT))) + (img[point] - get(region_means, minlabel, zero(Images.accum(CT))))/(region_pix_count[minlabel])
+
+        # Enqueue neighbours of `point`
+        for p in neighbourhood(point)
+            if checkbounds(Bool, img, p) && result[p] == -1
+                if haskey(neighbours, p)
+                    continue
+                end
+                δ = Inf
+                for tp in neighbourhood(p)
+                    if checkbounds(Bool, img, tp) && tp != p && result[tp] > 0
+                        δ = min(δ, diff_fn(region_means[result[tp]], img[p]))
+                    end
+                end
+                enqueue!(neighbours, p, δ)
+            end
+        end
+
     end
     SegmentedImage(result, labels, region_means, region_pix_count)
 end

--- a/test/region_growing.jl
+++ b/test/region_growing.jl
@@ -126,3 +126,127 @@ of_accum_type(p::Colorant) = Images.accum(typeof(p))(p)
     @test expected_means == seg.segment_means
     @test seg.image_indexmap == expected
 end
+
+@testset "Unseeded Region Growing" begin
+    # 2-D image
+    img = zeros(Gray{N0f8}, 10, 10)
+    img[6:10,4:8] = 0.5
+    img[3:7,2:6] = 0.8
+
+    expected = ones(Int, 10, 10)
+    expected[6:10,4:8] = 2
+    expected[3:7,2:6] = 3
+    expected_labels = [1,2,3]
+    expected_means = Dict(1 => of_accum_type(img[3,9]), 3 => of_accum_type(img[5,2]), 2 => of_accum_type(img[9,7]))
+    expected_count = Dict(1 => 56, 3 => 25, 2 => 19)
+
+    seg = unseeded_region_growing(img, 0.2)
+    @test all(label->(label in expected_labels), seg.segment_labels)
+    @test all(label->(label in seg.segment_labels), expected_labels)
+    @test expected_count == seg.segment_pixel_count
+    @test expected_means == seg.segment_means
+    @test seg.image_indexmap == expected
+
+    # Custom neighbourhood using a function
+    seg = unseeded_region_growing(img, 0.2, c->[CartesianIndex(c[1]-1,c[2]), CartesianIndex(c[1]+1,c[2]), CartesianIndex(c[1],c[2]-1), CartesianIndex(c[1],c[2]+1)])
+    @test all(label->(label in expected_labels), seg.segment_labels)
+    @test all(label->(label in seg.segment_labels), expected_labels)
+    @test expected_count == seg.segment_pixel_count
+    @test expected_means == seg.segment_means
+    @test seg.image_indexmap == expected
+
+    # Offset image
+    img = centered(img)
+    expected = centered(expected)
+    seg = unseeded_region_growing(img, 0.2)
+    @test all(label->(label in expected_labels), seg.segment_labels)
+    @test all(label->(label in seg.segment_labels), expected_labels)
+    @test expected_count == seg.segment_pixel_count
+    @test expected_means == seg.segment_means
+    @test seg.image_indexmap == expected
+
+    # Custom neighbourhood using a [5,5] kernel and varying threshold
+    img = zeros(Gray{N0f8}, 5, 5)
+    img[2:4,2:4] = 1
+    img[3,3] = 0.8
+
+    expected = fill(1,(5,5))
+    expected[2:4,2:4] = 2
+    expected_labels = [1,2]
+    expected_means = Dict(1=>Gray{Float64}(0.0), 2=>Gray{Float64}(8.8/9))
+    expected_count = Dict(2=>9, 1=>16)
+
+    seg = unseeded_region_growing(img, 0.2, (5,5))
+    @test all(label->(label in expected_labels), seg.segment_labels)
+    @test all(label->(label in seg.segment_labels), expected_labels)
+    @test expected_count == seg.segment_pixel_count
+    @test all(label->(expected_means[label] ≈ seg.segment_means[label]), seg.segment_labels)
+    @test seg.image_indexmap == expected
+
+    expected = ones(Int, 5, 5)
+    expected[2:4,2:4] = 3
+    expected[3,3] = 2
+    expected_labels = [1,2,3]
+    expected_means = Dict(1=>Gray{N0f8}(0.0), 3=>Gray{N0f8}(1.0), 2=>Gray{N0f8}(0.8))
+    expected_count = Dict(1=>16, 2=>1, 3=>8)
+
+    seg = unseeded_region_growing(img, 0.1, (5,5))
+    @test all(label->(label in expected_labels), seg.segment_labels)
+    @test all(label->(label in seg.segment_labels), expected_labels)
+    @test expected_count == seg.segment_pixel_count
+    @test expected_means == seg.segment_means
+    @test seg.image_indexmap == expected
+
+    expected = ones(Int, 5, 5)
+    expected[2:4,2:4] = 2
+    expected[3,3] = 3
+    expected_labels = [1,2,3]
+    expected_means = Dict(1=>Gray{N0f8}(0.0), 2=>Gray{N0f8}(1.0), 3=>Gray{N0f8}(0.8))
+    expected_count = Dict(1=>16, 3=>1, 2=>8)
+
+    seg = unseeded_region_growing(img, 0.1, (3,3))
+    @test all(label->(label in expected_labels), seg.segment_labels)
+    @test all(label->(label in seg.segment_labels), expected_labels)
+    @test expected_count == seg.segment_pixel_count
+    @test expected_means == seg.segment_means
+    @test seg.image_indexmap == expected
+
+    # 3-d image
+    img = zeros(RGB{N0f8},(9,9,9))
+    img[3:7,3:7,3:7] = RGB{N0f8}(0.5,0.5,0.5)
+    img[2:5,5:9,4:6] = RGB{N0f8}(0.8,0.8,0.8)
+
+    expected = ones(Int, (9,9,9))
+    expected[3:7,3:7,3:7] = 2
+    expected[2:5,5:9,4:6] = 3
+    expected_labels = [1,2,3]
+    expected_means = Dict(1=>of_accum_type(img[1,1,1]), 2=>of_accum_type(img[3,3,3]), 3=>of_accum_type(img[2,5,4]))
+    expected_count = Dict(1=>571, 2=>98, 3=>60)
+
+    seg = unseeded_region_growing(img, 0.2)
+    @test all(label->(label in expected_labels), seg.segment_labels)
+    @test all(label->(label in seg.segment_labels), expected_labels)
+    @test expected_count == seg.segment_pixel_count
+    @test expected_means == seg.segment_means
+    @test seg.image_indexmap == expected
+
+    # custom diff_fn
+    img = zeros(RGB{N0f8},(3,3))
+    img[1:3,1] = RGB{N0f8}(0.4,1,0)
+    img[1:3,2] = RGB{N0f8}(0.2,1,0)
+
+    expected = ones(Int, (3,3))
+    expected[1:3,2] = 2
+    expected[1:3,3] = 3
+    expected_labels = [1,2,3]
+    expected_means = Dict(1=>of_accum_type(img[1,1]), 3=>of_accum_type(img[1,3]), 2=>of_accum_type(img[1,2]))
+    expected_count = Dict(1=>3, 2=>3, 3=>3)
+
+    seg = unseeded_region_growing(img, 0.2, [3,3], (c1,c2)->abs(of_accum_type(c1).r - of_accum_type(c2).r))
+    @test all(label->(label in expected_labels), seg.segment_labels)
+    @test all(label->(label in seg.segment_labels), expected_labels)
+    @test expected_count == seg.segment_pixel_count
+    @test expected_means == seg.segment_means
+    @test seg.image_indexmap == expected
+
+end


### PR DESCRIPTION
An implementation of the unseeded region growing algorithm.
The API is consistent with the SRG algorithm and output is also of type `SegmentedImage`. It supports N-dimensional arrays with arbitrary indices. Similar to SRG, it can take custom neighborhood as a `Function` as well as `Union{Vector{Int}, NTuple{N, Int}}`. Tests and docstring have been added.

| Threshold | Output | Compression percentage|
| ------------- | ----------| -------------------------|
| Original    | ![scene](https://user-images.githubusercontent.com/15063205/27087931-ecf2490c-5073-11e7-902f-e28b68975979.jpg) | 0 % |
| 0.02 | ![seg1](https://user-images.githubusercontent.com/15063205/27088052-41996c74-5074-11e7-9ff1-1941d1be88c4.jpg) | 50% |
| 0.05 | ![seg2](https://user-images.githubusercontent.com/15063205/27088179-9761458c-5074-11e7-9305-91411d862b22.jpg) | 62.5% |
| 0.1 | ![seg3](https://user-images.githubusercontent.com/15063205/27088318-f556be88-5074-11e7-9b1e-271963060e90.jpg) | 70.8% |
| 0.2 | ![seg4](https://user-images.githubusercontent.com/15063205/27088449-4ed7774a-5075-11e7-91bd-f18438ca57a0.jpg) | 79.2% |

The color of the ith segment corresponds to `segment_means[i]`.