### PR TITLE
Added fast scanning algorithm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.5
   - 0.6
   - nightly
 notifications:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.5
+julia 0.6
 Images 0.9
 DataStructures 0.5.3

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 environment:
   matrix:
-  - JULIAVERSION: "julialang/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
-  - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
   - JULIAVERSION: "julialang/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
   - JULIAVERSION: "julialang/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"

--- a/src/ImageSegmentation.jl
+++ b/src/ImageSegmentation.jl
@@ -27,7 +27,6 @@ export
     unseeded_region_growing,
     felzenszwalb,
     fast_scanning,
-    Nfast_scanning,
 
     # types
     SegmentedImage,

--- a/src/ImageSegmentation.jl
+++ b/src/ImageSegmentation.jl
@@ -2,7 +2,7 @@ __precompile__()
 
 module ImageSegmentation
 
-using Images, DataStructures, StaticArrays
+using Images, DataStructures, StaticArrays, ImageFiltering
 
 # For efficient hashing of CartesianIndex
 if !isdefined(Base.IteratorsMD, :cartindexhash_seed)

--- a/src/ImageSegmentation.jl
+++ b/src/ImageSegmentation.jl
@@ -4,25 +4,31 @@ module ImageSegmentation
 
 using Images, DataStructures, StaticArrays
 
+# For efficient hashing of CartesianIndex
+if !isdefined(Base.IteratorsMD, :cartindexhash_seed)
+    const cartindexhash_seed = UInt == UInt64 ? 0xd60ca92f8284b8b0 : 0xf2ea7c2e
+    function Base.hash(ci::CartesianIndex, h::UInt)
+        h += cartindexhash_seed
+        for i in ci.I
+            h = hash(i, h)
+        end
+        return h
+    end
+end
+
 include("core.jl")
 include("region_growing.jl")
-<<<<<<< 0d8720a6e224164e69d14c48dcdf4a042d358dda
 include("felzenszwalb.jl")
-=======
 include("fast_scanning.jl")
->>>>>>> Added fast scanning algorithm
 
 export
     # methods
     seeded_region_growing,
     unseeded_region_growing,
-<<<<<<< 0d8720a6e224164e69d14c48dcdf4a042d358dda
     felzenszwalb,
-    
-=======
-    fast_scanning
+    fast_scanning,
+    Nfast_scanning,
 
->>>>>>> Added fast scanning algorithm
     # types
     SegmentedImage,
     ImageEdge

--- a/src/ImageSegmentation.jl
+++ b/src/ImageSegmentation.jl
@@ -6,14 +6,23 @@ using Images, DataStructures, StaticArrays
 
 include("core.jl")
 include("region_growing.jl")
+<<<<<<< 0d8720a6e224164e69d14c48dcdf4a042d358dda
 include("felzenszwalb.jl")
+=======
+include("fast_scanning.jl")
+>>>>>>> Added fast scanning algorithm
 
 export
     # methods
     seeded_region_growing,
     unseeded_region_growing,
+<<<<<<< 0d8720a6e224164e69d14c48dcdf4a042d358dda
     felzenszwalb,
     
+=======
+    fast_scanning
+
+>>>>>>> Added fast scanning algorithm
     # types
     SegmentedImage,
     ImageEdge

--- a/src/core.jl
+++ b/src/core.jl
@@ -2,7 +2,7 @@
 `SegmentedImage` type contains the index-label mapping, assigned labels,
 segment mean intensity and pixel count of each segment.
 """
-immutable SegmentedImage{T<:AbstractArray,U<:Colorant}
+immutable SegmentedImage{T<:AbstractArray,U<:Union{Colorant,Real}}
     image_indexmap::T
     segment_labels::Vector{Int}
     segment_means::Dict{Int,U}

--- a/src/fast_scanning.jl
+++ b/src/fast_scanning.jl
@@ -2,59 +2,31 @@
 # for 2-D images
 function fast_scanning{CT<:Colorant}(img::AbstractArray{CT,2}, threshold::Real, diff_fn::Function = default_diff_fn)
 
-    # Bfs coloring function
-    function bfs_color!(result::AbstractArray{Int, 2}, start_point::CartesianIndex{2}, label::Int)
-
-        prev_label = result[start_point]
-        bfs_queue  = Vector{CartesianIndex{2}}()
-        visited    = Set{CartesianIndex{2}}()
-
-        push!(visited, start_point)
-        push!(bfs_queue, start_point)
-
-        while !isempty(bfs_queue)
-            point = shift!(bfs_queue)
-            result[point] = label
-            for i in (CartesianIndex(point[1]-1,point[2]), CartesianIndex(point[1],point[2]-1), CartesianIndex(point[1]+1,point[2]), CartesianIndex(point[1],point[2]+1))
-                if checkbounds(Bool, result, i) && result[i] == prev_label
-                    if i ∉ visited
-                        push!(visited, i)
-                        push!(bfs_queue, i)
-                    end
-                end
-            end
-        end
-        result
-    end
-
     # Required data structures
     result              =   similar(dims->fill(-1,dims), indices(img))      # Array to store labels
     region_means        =   Dict{Int, Images.accum(CT)}()                   # A map conatining (label, mean) pairs
     region_pix_count    =   Dict{Int, Int}()                                # A map conatining (label, count) pairs
-    labels              =   Vector{Int}()                                   # Vector containing list of labels
-    removed_labels      =   Vector{Int}()                                   # Vector containing list of labels to be removed
+    temp_labels         =   IntDisjointSets(0)                              # Disjoint set to store map labels with their equivalence class
 
     for point in CartesianRange(indices(img))
-
         top_point = CartesianIndex(point[1]-1, point[2])
         left_point = CartesianIndex(point[1], point[2]-1)
         top_label = -1
         left_label = -1
 
-        if checkbounds(Bool, img, top_point) && diff_fn(region_means[result[top_point]], img[point]) < threshold
-            top_label = result[top_point]
+        if checkbounds(Bool, img, top_point) && diff_fn(region_means[find_root(temp_labels, result[top_point])], img[point]) < threshold
+            top_label = find_root(temp_labels, result[top_point])
         end
-        if checkbounds(Bool, img, left_point) && diff_fn(region_means[result[left_point]], img[point]) < threshold
-            left_label = result[left_point]
+        if checkbounds(Bool, img, left_point) && diff_fn(region_means[find_root(temp_labels, result[left_point])], img[point]) < threshold
+            left_label = find_root(temp_labels, result[left_point])
         end
 
         # If no valid point found then create a new label
         if top_label == -1 && left_label == -1
-            new_label = length(labels) + 1
+            new_label = push!(temp_labels)
             result[point] = new_label
             region_means[new_label] = img[point]
             region_pix_count[new_label] = 1
-            push!(labels, new_label)
 
         # Else if one valid label found, assign that label
         elseif top_label == -1 || left_label == -1
@@ -73,163 +45,108 @@ function fast_scanning{CT<:Colorant}(img::AbstractArray{CT,2}, threshold::Real, 
 
             # Else replace label having less pixel count with that having larger one and assign the label having larger pixel count
             else
-                min_count_point = region_pix_count[top_label] < region_pix_count[left_label] ? top_point: left_point
-                min_count_label = result[min_count_point]
-                max_count_label = min_count_label == top_label ? left_label : top_label
+                new_root = union!(temp_labels, top_label, left_label)
+                result[point] = new_root
 
-                result[point] = max_count_label
-                bfs_color!(result, min_count_point, max_count_label)
+                delete_label = top_label == new_root ? left_label : top_label
+                update_label = result[point]
 
-                region_pix_count[min_count_label] += 1
-                region_pix_count[max_count_label] += region_pix_count[min_count_label]
-                region_means[min_count_label] += (img[point] - region_means[min_count_label])/(region_pix_count[min_count_label])
-                region_means[max_count_label] += (region_means[min_count_label] - region_means[max_count_label])*region_pix_count[min_count_label]/region_pix_count[max_count_label]
+                region_pix_count[update_label] += region_pix_count[delete_label]
+                region_means[update_label] += (region_means[delete_label] - region_means[update_label])*region_pix_count[delete_label]/region_pix_count[update_label]
+                region_pix_count[update_label] += 1
+                region_means[update_label] += (img[point] - region_means[update_label])/(region_pix_count[update_label])
 
-                # Remove label result[i] from region_means, region_pix_count
-                delete!(region_pix_count, min_count_label)
-                delete!(region_means, min_count_label)
-                push!(removed_labels, min_count_label)
+                delete!(region_pix_count, delete_label)
+                delete!(region_means, delete_label)
             end
         end
     end
 
-    # Remove labels that have been recolored due to the bfs calls
-    @noinline sort_fn!(removed_labels) = sort!(removed_labels)
-    sort_fn!(removed_labels)
-    deleteat!(labels, removed_labels)
+    for point in CartesianRange(indices(img))
+        result[point] = find_root(temp_labels, result[point])
+    end
 
-    SegmentedImage(result, labels, region_means, region_pix_count)
+    SegmentedImage(result, unique(temp_labels.parents), region_means, region_pix_count)
 
 end
 
 
-# For N-D images
-
-function fast_scanning{CT<:Colorant,N}(img::AbstractArray{CT,N}, threshold::Real, diff_fn::Function = default_diff_fn)
+# for N-D images
+function Nfast_scanning{CT<:Colorant,N}(img::AbstractArray{CT,N}, threshold::Real, diff_fn::Function = default_diff_fn)
 
     # Neighbourhood functions
     _diagmN = diagm([1 for i in 1:N])
     half_region = ntuple(i-> CartesianIndex{N}(ntuple(j->_diagmN[j,i], Val{N})), Val{N})
-    neg_neighbourhood{N}(x::CartesianIndex{N}) = ntuple(i-> x-half_region[i], Val{N})
-    pos_neighbourhood{N}(x::CartesianIndex{N}) = ntuple(i-> x+half_region[i], Val{N})
-
-    # Bfs coloring function
-    function bfs_color!{N}(result::AbstractArray{Int, N}, start_point::CartesianIndex{N}, label::Int)
-
-        local prev_label = result[start_point]
-        local bfs_queue = Vector{CartesianIndex{N}}()
-        local visited = Set{CartesianIndex{N}}()
-
-        push!(visited, start_point)
-        push!(bfs_queue, start_point)
-
-        while !isempty(bfs_queue)
-            point = shift!(bfs_queue)
-            result[point] = label
-            for i in neg_neighbourhood(point)
-                if checkbounds(Bool, result, i) && result[i] == prev_label
-                    if i ∉ visited
-                        push!(visited, i)
-                        push!(bfs_queue, i)
-                    end
-                end
-            end
-            for i in pos_neighbourhood(point)
-                if checkbounds(Bool, result, i) && result[i] == prev_label
-                    if i ∉ visited
-                        push!(visited, i)
-                        push!(bfs_queue, i)
-                    end
-                end
-            end
-        end
-
-        result
-
-    end
+    n_gen(region) = x -> ntuple(i-> x-region[i], Val{N})
+    neighbourhood = n_gen(half_region)
 
     # Required data structures
     result              =   similar(dims->fill(-1,dims), indices(img))      # Array to store labels
     region_means        =   Dict{Int, Images.accum(CT)}()                   # A map conatining (label, mean) pairs
     region_pix_count    =   Dict{Int, Int}()                                # A map conatining (label, count) pairs
-    labels              =   Vector{Int}()                                   # Vector containing list of labels
-    removed_labels      =   Vector{Int}()                                   # Vector containing list of labels to be removed
-
+    temp_labels         =   IntDisjointSets(0)                              # Disjoint set to store map labels with their equivalence class
+    v                   =   MVector{N,Int}()                                # MVector to store valid neighbours
     for point in CartesianRange(indices(img))
-        v = Vector{CartesianIndex{N}}()
+        sz = 0
         same_label = true
         prev_label = 0
-        for p in neg_neighbourhood(point)
-            if checkbounds(Bool, img, p) && result[p] > 0
-                if diff_fn(region_means[result[p]], img[point]) < threshold
+        for p in neighbourhood(point)
+            if checkbounds(Bool, img, p)
+                root_p = find_root(temp_labels, result[p])
+                if diff_fn(region_means[root_p], img[point]) < threshold
                     if prev_label == 0
-                        prev_label = result[p]
-                    elseif prev_label != result[p]
+                        prev_label = root_p
+                    elseif prev_label != root_p
                         same_label = false
                     end
-                    push!(v, p)
+                    sz += 1
+                    v[sz] = find_root(temp_labels, root_p)
                 end
             end
         end
 
         # If no valid label found
-        if length(v) == 0
+        if sz == 0
             # Assign a new label
-            new_label = length(labels) + 1
+            new_label = push!(temp_labels)
             result[point] = new_label
             region_means[new_label] = img[point]
             region_pix_count[new_label] = 1
-            push!(labels, new_label)
 
         # If all labels are same
         elseif same_label
+
             result[point] = prev_label
             region_pix_count[prev_label] += 1
             region_means[prev_label] += (img[point] - region_means[prev_label])/(region_pix_count[prev_label])
         else
             # Merge segments and assign to this new label
-            # get max pixel_count segment
-            d = Dict{Int, Float64}()
-            for i in v
-                cur_label = result[i]
-                if ! haskey(d, cur_label)
-                    d[cur_label] = region_pix_count[cur_label]
-                end
-            end
-            max_count = -Inf
-            max_count_label = -1
-            for k in d
-                if k[2] > max_count
-                    max_count = k[2]
-                    max_count_label = k[1]
-                end
+            union_label = v[1]
+            for i in 1:sz
+                union_label = union!(temp_labels, union_label, v[i])
             end
 
-            result[point] = max_count_label
-            region_pix_count[max_count_label] += 1
-            region_means[max_count_label] += (img[point] - region_means[max_count_label])/(region_pix_count[max_count_label])
+            result[point] = union_label
+            region_pix_count[union_label] += 1
+            region_means[union_label] += (img[point] - region_means[union_label])/(region_pix_count[union_label])
 
             # Apply bfs on all points in v to make their label `max_count_label`
-            for i in v
-                if result[i] != max_count_label
-                    delete_label = result[i]
-                    bfs_color!(result, i, max_count_label)
-
-                    region_pix_count[max_count_label] += region_pix_count[result[i]]
-                    region_means[max_count_label] += (region_means[result[i]] - region_means[max_count_label])*region_pix_count[result[i]]/region_pix_count[max_count_label]
+            for i in 1:sz
+                if v[i] != union_label
+                    region_pix_count[union_label] += region_pix_count[v[i]]
+                    region_means[union_label] += (region_means[v[i]] - region_means[union_label])*region_pix_count[v[i]]/region_pix_count[union_label]
 
                     # Remove label result[i] from region_means, region_pix_count
-                    delete!(region_pix_count,delete_label)
-                    delete!(region_means,delete_label)
-                    push!(removed_labels,delete_label)
+                    delete!(region_pix_count,v[i])
+                    delete!(region_means,v[i])
                 end
             end
         end
     end
 
-    @noinline sort_fn!(removed_labels) = sort!(removed_labels)
-    sort_fn!(removed_labels)
-    deleteat!(labels, removed_labels)
+    for point in CartesianRange(indices(img))
+        result[point] = find_root(temp_labels, result[point])
+    end
 
-    SegmentedImage(result, labels, region_means, region_pix_count)
+    SegmentedImage(result, unique(temp_labels.parents), region_means, region_pix_count)
 end

--- a/src/fast_scanning.jl
+++ b/src/fast_scanning.jl
@@ -79,13 +79,12 @@ function fast_scanning{CT<:Union{Colorant,Real},N}(img::AbstractArray{CT,N}, thr
             for i in 1:sz
                 union_label = union!(temp_labels, union_label, v_neigh[i])
             end
-
             result[point] = union_label
             region_pix_count[union_label] += 1
             region_means[union_label] += (img[point] - region_means[union_label])/(region_pix_count[union_label])
 
             for i in 1:sz
-                if v_neigh[i] != union_label
+                if v_neigh[i] != union_label && haskey(region_pix_count, v_neigh[i])
                     region_pix_count[union_label] += region_pix_count[v_neigh[i]]
                     region_means[union_label] += (region_means[v_neigh[i]] - region_means[union_label])*region_pix_count[v_neigh[i]]/region_pix_count[union_label]
 

--- a/src/fast_scanning.jl
+++ b/src/fast_scanning.jl
@@ -1,0 +1,235 @@
+
+# for 2-D images
+function fast_scanning{CT<:Colorant}(img::AbstractArray{CT,2}, threshold::Real, diff_fn::Function = default_diff_fn)
+
+    # Bfs coloring function
+    function bfs_color!(result::AbstractArray{Int, 2}, start_point::CartesianIndex{2}, label::Int)
+
+        prev_label = result[start_point]
+        bfs_queue  = Vector{CartesianIndex{2}}()
+        visited    = Set{CartesianIndex{2}}()
+
+        push!(visited, start_point)
+        push!(bfs_queue, start_point)
+
+        while !isempty(bfs_queue)
+            point = shift!(bfs_queue)
+            result[point] = label
+            for i in (CartesianIndex(point[1]-1,point[2]), CartesianIndex(point[1],point[2]-1), CartesianIndex(point[1]+1,point[2]), CartesianIndex(point[1],point[2]+1))
+                if checkbounds(Bool, result, i) && result[i] == prev_label
+                    if i ∉ visited
+                        push!(visited, i)
+                        push!(bfs_queue, i)
+                    end
+                end
+            end
+        end
+        result
+    end
+
+    # Required data structures
+    result              =   similar(dims->fill(-1,dims), indices(img))      # Array to store labels
+    region_means        =   Dict{Int, Images.accum(CT)}()                   # A map conatining (label, mean) pairs
+    region_pix_count    =   Dict{Int, Int}()                                # A map conatining (label, count) pairs
+    labels              =   Vector{Int}()                                   # Vector containing list of labels
+    removed_labels      =   Vector{Int}()                                   # Vector containing list of labels to be removed
+
+    for point in CartesianRange(indices(img))
+
+        top_point = CartesianIndex(point[1]-1, point[2])
+        left_point = CartesianIndex(point[1], point[2]-1)
+        top_label = -1
+        left_label = -1
+
+        if checkbounds(Bool, img, top_point) && diff_fn(region_means[result[top_point]], img[point]) < threshold
+            top_label = result[top_point]
+        end
+        if checkbounds(Bool, img, left_point) && diff_fn(region_means[result[left_point]], img[point]) < threshold
+            left_label = result[left_point]
+        end
+
+        # If no valid point found then create a new label
+        if top_label == -1 && left_label == -1
+            new_label = length(labels) + 1
+            result[point] = new_label
+            region_means[new_label] = img[point]
+            region_pix_count[new_label] = 1
+            push!(labels, new_label)
+
+        # Else if one valid label found, assign that label
+        elseif top_label == -1 || left_label == -1
+            valid_label = top_label == -1 ? left_label : top_label
+            result[point] = valid_label
+            region_pix_count[valid_label] += 1
+            region_means[valid_label] += (img[point] - region_means[valid_label])/(region_pix_count[valid_label])
+
+        # Else if both labels are valid
+        else
+            # If both the labels are same, assign that label
+            if top_label == left_label
+                result[point] = top_label
+                region_pix_count[top_label] += 1
+                region_means[top_label] += (img[point] - region_means[top_label])/(region_pix_count[top_label])
+
+            # Else replace label having less pixel count with that having larger one and assign the label having larger pixel count
+            else
+                min_count_point = region_pix_count[top_label] < region_pix_count[left_label] ? top_point: left_point
+                min_count_label = result[min_count_point]
+                max_count_label = min_count_label == top_label ? left_label : top_label
+
+                result[point] = max_count_label
+                bfs_color!(result, min_count_point, max_count_label)
+
+                region_pix_count[min_count_label] += 1
+                region_pix_count[max_count_label] += region_pix_count[min_count_label]
+                region_means[min_count_label] += (img[point] - region_means[min_count_label])/(region_pix_count[min_count_label])
+                region_means[max_count_label] += (region_means[min_count_label] - region_means[max_count_label])*region_pix_count[min_count_label]/region_pix_count[max_count_label]
+
+                # Remove label result[i] from region_means, region_pix_count
+                delete!(region_pix_count, min_count_label)
+                delete!(region_means, min_count_label)
+                push!(removed_labels, min_count_label)
+            end
+        end
+    end
+
+    # Remove labels that have been recolored due to the bfs calls
+    @noinline sort_fn!(removed_labels) = sort!(removed_labels)
+    sort_fn!(removed_labels)
+    deleteat!(labels, removed_labels)
+
+    SegmentedImage(result, labels, region_means, region_pix_count)
+
+end
+
+
+# For N-D images
+
+function fast_scanning{CT<:Colorant,N}(img::AbstractArray{CT,N}, threshold::Real, diff_fn::Function = default_diff_fn)
+
+    # Neighbourhood functions
+    _diagmN = diagm([1 for i in 1:N])
+    half_region = ntuple(i-> CartesianIndex{N}(ntuple(j->_diagmN[j,i], Val{N})), Val{N})
+    neg_neighbourhood{N}(x::CartesianIndex{N}) = ntuple(i-> x-half_region[i], Val{N})
+    pos_neighbourhood{N}(x::CartesianIndex{N}) = ntuple(i-> x+half_region[i], Val{N})
+
+    # Bfs coloring function
+    function bfs_color!{N}(result::AbstractArray{Int, N}, start_point::CartesianIndex{N}, label::Int)
+
+        local prev_label = result[start_point]
+        local bfs_queue = Vector{CartesianIndex{N}}()
+        local visited = Set{CartesianIndex{N}}()
+
+        push!(visited, start_point)
+        push!(bfs_queue, start_point)
+
+        while !isempty(bfs_queue)
+            point = shift!(bfs_queue)
+            result[point] = label
+            for i in neg_neighbourhood(point)
+                if checkbounds(Bool, result, i) && result[i] == prev_label
+                    if i ∉ visited
+                        push!(visited, i)
+                        push!(bfs_queue, i)
+                    end
+                end
+            end
+            for i in pos_neighbourhood(point)
+                if checkbounds(Bool, result, i) && result[i] == prev_label
+                    if i ∉ visited
+                        push!(visited, i)
+                        push!(bfs_queue, i)
+                    end
+                end
+            end
+        end
+
+        result
+
+    end
+
+    # Required data structures
+    result              =   similar(dims->fill(-1,dims), indices(img))      # Array to store labels
+    region_means        =   Dict{Int, Images.accum(CT)}()                   # A map conatining (label, mean) pairs
+    region_pix_count    =   Dict{Int, Int}()                                # A map conatining (label, count) pairs
+    labels              =   Vector{Int}()                                   # Vector containing list of labels
+    removed_labels      =   Vector{Int}()                                   # Vector containing list of labels to be removed
+
+    for point in CartesianRange(indices(img))
+        v = Vector{CartesianIndex{N}}()
+        same_label = true
+        prev_label = 0
+        for p in neg_neighbourhood(point)
+            if checkbounds(Bool, img, p) && result[p] > 0
+                if diff_fn(region_means[result[p]], img[point]) < threshold
+                    if prev_label == 0
+                        prev_label = result[p]
+                    elseif prev_label != result[p]
+                        same_label = false
+                    end
+                    push!(v, p)
+                end
+            end
+        end
+
+        # If no valid label found
+        if length(v) == 0
+            # Assign a new label
+            new_label = length(labels) + 1
+            result[point] = new_label
+            region_means[new_label] = img[point]
+            region_pix_count[new_label] = 1
+            push!(labels, new_label)
+
+        # If all labels are same
+        elseif same_label
+            result[point] = prev_label
+            region_pix_count[prev_label] += 1
+            region_means[prev_label] += (img[point] - region_means[prev_label])/(region_pix_count[prev_label])
+        else
+            # Merge segments and assign to this new label
+            # get max pixel_count segment
+            d = Dict{Int, Float64}()
+            for i in v
+                cur_label = result[i]
+                if ! haskey(d, cur_label)
+                    d[cur_label] = region_pix_count[cur_label]
+                end
+            end
+            max_count = -Inf
+            max_count_label = -1
+            for k in d
+                if k[2] > max_count
+                    max_count = k[2]
+                    max_count_label = k[1]
+                end
+            end
+
+            result[point] = max_count_label
+            region_pix_count[max_count_label] += 1
+            region_means[max_count_label] += (img[point] - region_means[max_count_label])/(region_pix_count[max_count_label])
+
+            # Apply bfs on all points in v to make their label `max_count_label`
+            for i in v
+                if result[i] != max_count_label
+                    delete_label = result[i]
+                    bfs_color!(result, i, max_count_label)
+
+                    region_pix_count[max_count_label] += region_pix_count[result[i]]
+                    region_means[max_count_label] += (region_means[result[i]] - region_means[max_count_label])*region_pix_count[result[i]]/region_pix_count[max_count_label]
+
+                    # Remove label result[i] from region_means, region_pix_count
+                    delete!(region_pix_count,delete_label)
+                    delete!(region_means,delete_label)
+                    push!(removed_labels,delete_label)
+                end
+            end
+        end
+    end
+
+    @noinline sort_fn!(removed_labels) = sort!(removed_labels)
+    sort_fn!(removed_labels)
+    deleteat!(labels, removed_labels)
+
+    SegmentedImage(result, labels, region_means, region_pix_count)
+end

--- a/src/fast_scanning.jl
+++ b/src/fast_scanning.jl
@@ -20,6 +20,9 @@ getscalar{T<:Real,N}(A::AbstractArray{T,N}, i::CartesianIndex{N}, block_length::
 
 getscalar(a::Real, i...) = a
 
+fast_scanning{CT<:Images.NumberLike,N}(img::AbstractArray{CT,N}, block::NTuple{N,Int} =
+    ntuple(i->4,Val{N})) = fast_scanning(img, adaptive_thres(img, block))
+
 """
     seg_img = fast_scanning(img, threshold, [diff_fn])
 
@@ -47,14 +50,16 @@ julia> seg.image_indexmap
  1  4  5
  4  4  4
  3  4  6
-
 ```
-"""
-fast_scanning{CT<:Images.NumberLike,N}(img::AbstractArray{CT,N}, block::NTuple{N,Int} = ntuple(i->4,Val{N})) = fast_scanning(img, adaptive_thres(img, block))
 
+# Citation:
+
+Jian-Jiun Ding, Cheng-Jin Kuo, Wen-Chih Hong,
+"An efficient image segmentation technique by fast scanning and adaptive merging"
+"""
 function fast_scanning{CT<:Union{Colorant,Real},N}(img::AbstractArray{CT,N}, threshold::Union{AbstractArray,Real}, diff_fn::Function = default_diff_fn)
 
-    if typeof(threshold) <: AbstractArray
+    if threshold isa AbstractArray
         ndims(img) == ndims(threshold) || error("Dimension count of image and threshold do not match")
     end
 

--- a/src/fast_scanning.jl
+++ b/src/fast_scanning.jl
@@ -1,5 +1,32 @@
-# for N-D images
-function fast_scanning{CT<:Colorant,N}(img::AbstractArray{CT,N}, threshold::Real, diff_fn::Function = default_diff_fn)
+"""
+    seg_img = fast_scanning(img, threshold, [diff_fn])
+
+Segments the N-D image using a fast scanning algorithm and returns a
+[`SegmentedImage`](@ref) containing information about the segments.
+
+# Arguments:
+* `img`         : N-D image to be segmented (arbitrary indices are allowed)
+* `threshold`   : Upper bound of the difference measure (δ) for considering
+                  pixel into same segment
+* `diff_fn`     : (Optional) Function that returns a difference measure (δ)
+                  between the mean color of a region and color of a point
+
+# Examples:
+
+```jldoctest
+julia> img = zeros(Float64, (3,3));
+julia> img[2,:] = 0.5;
+julia> img[:,2] = 0.6;
+julia> seg = fast_scanning(img, 0.2);
+julia> seg.image_indexmap
+3×3 Array{Int64,2}:
+ 1  4  5
+ 4  4  4
+ 3  4  6
+
+```
+"""
+function fast_scanning{CT<:Union{Colorant,Real},N}(img::AbstractArray{CT,N}, threshold::Real, diff_fn::Function = default_diff_fn)
 
     # Neighbourhood function
     _diagmN = diagm([1 for i in 1:N])
@@ -43,7 +70,6 @@ function fast_scanning{CT<:Colorant,N}(img::AbstractArray{CT,N}, threshold::Real
 
         # If all labels are same
         elseif same_label
-
             result[point] = prev_label
             region_pix_count[prev_label] += 1
             region_means[prev_label] += (img[point] - region_means[prev_label])/(region_pix_count[prev_label])

--- a/src/fast_scanning.jl
+++ b/src/fast_scanning.jl
@@ -1,80 +1,7 @@
-
-# for 2-D images
-function fast_scanning{CT<:Colorant}(img::AbstractArray{CT,2}, threshold::Real, diff_fn::Function = default_diff_fn)
-
-    # Required data structures
-    result              =   similar(dims->fill(-1,dims), indices(img))      # Array to store labels
-    region_means        =   Dict{Int, Images.accum(CT)}()                   # A map conatining (label, mean) pairs
-    region_pix_count    =   Dict{Int, Int}()                                # A map conatining (label, count) pairs
-    temp_labels         =   IntDisjointSets(0)                              # Disjoint set to store map labels with their equivalence class
-
-    for point in CartesianRange(indices(img))
-        top_point = CartesianIndex(point[1]-1, point[2])
-        left_point = CartesianIndex(point[1], point[2]-1)
-        top_label = -1
-        left_label = -1
-
-        if checkbounds(Bool, img, top_point) && diff_fn(region_means[find_root(temp_labels, result[top_point])], img[point]) < threshold
-            top_label = find_root(temp_labels, result[top_point])
-        end
-        if checkbounds(Bool, img, left_point) && diff_fn(region_means[find_root(temp_labels, result[left_point])], img[point]) < threshold
-            left_label = find_root(temp_labels, result[left_point])
-        end
-
-        # If no valid point found then create a new label
-        if top_label == -1 && left_label == -1
-            new_label = push!(temp_labels)
-            result[point] = new_label
-            region_means[new_label] = img[point]
-            region_pix_count[new_label] = 1
-
-        # Else if one valid label found, assign that label
-        elseif top_label == -1 || left_label == -1
-            valid_label = top_label == -1 ? left_label : top_label
-            result[point] = valid_label
-            region_pix_count[valid_label] += 1
-            region_means[valid_label] += (img[point] - region_means[valid_label])/(region_pix_count[valid_label])
-
-        # Else if both labels are valid
-        else
-            # If both the labels are same, assign that label
-            if top_label == left_label
-                result[point] = top_label
-                region_pix_count[top_label] += 1
-                region_means[top_label] += (img[point] - region_means[top_label])/(region_pix_count[top_label])
-
-            # Else replace label having less pixel count with that having larger one and assign the label having larger pixel count
-            else
-                new_root = union!(temp_labels, top_label, left_label)
-                result[point] = new_root
-
-                delete_label = top_label == new_root ? left_label : top_label
-                update_label = result[point]
-
-                region_pix_count[update_label] += region_pix_count[delete_label]
-                region_means[update_label] += (region_means[delete_label] - region_means[update_label])*region_pix_count[delete_label]/region_pix_count[update_label]
-                region_pix_count[update_label] += 1
-                region_means[update_label] += (img[point] - region_means[update_label])/(region_pix_count[update_label])
-
-                delete!(region_pix_count, delete_label)
-                delete!(region_means, delete_label)
-            end
-        end
-    end
-
-    for point in CartesianRange(indices(img))
-        result[point] = find_root(temp_labels, result[point])
-    end
-
-    SegmentedImage(result, unique(temp_labels.parents), region_means, region_pix_count)
-
-end
-
-
 # for N-D images
-function Nfast_scanning{CT<:Colorant,N}(img::AbstractArray{CT,N}, threshold::Real, diff_fn::Function = default_diff_fn)
+function fast_scanning{CT<:Colorant,N}(img::AbstractArray{CT,N}, threshold::Real, diff_fn::Function = default_diff_fn)
 
-    # Neighbourhood functions
+    # Neighbourhood function
     _diagmN = diagm([1 for i in 1:N])
     half_region = ntuple(i-> CartesianIndex{N}(ntuple(j->_diagmN[j,i], Val{N})), Val{N})
     n_gen(region) = x -> ntuple(i-> x-region[i], Val{N})
@@ -84,8 +11,9 @@ function Nfast_scanning{CT<:Colorant,N}(img::AbstractArray{CT,N}, threshold::Rea
     result              =   similar(dims->fill(-1,dims), indices(img))      # Array to store labels
     region_means        =   Dict{Int, Images.accum(CT)}()                   # A map conatining (label, mean) pairs
     region_pix_count    =   Dict{Int, Int}()                                # A map conatining (label, count) pairs
-    temp_labels         =   IntDisjointSets(0)                              # Disjoint set to store map labels with their equivalence class
-    v                   =   MVector{N,Int}()                                # MVector to store valid neighbours
+    temp_labels         =   IntDisjointSets(0)                              # Disjoint set to map labels to their equivalence class
+    v_neigh             =   MVector{N,Int}()                                # MVector to store valid neighbours
+
     for point in CartesianRange(indices(img))
         sz = 0
         same_label = true
@@ -100,7 +28,7 @@ function Nfast_scanning{CT<:Colorant,N}(img::AbstractArray{CT,N}, threshold::Rea
                         same_label = false
                     end
                     sz += 1
-                    v[sz] = find_root(temp_labels, root_p)
+                    v_neigh[sz] = find_root(temp_labels, root_p)
                 end
             end
         end
@@ -121,24 +49,23 @@ function Nfast_scanning{CT<:Colorant,N}(img::AbstractArray{CT,N}, threshold::Rea
             region_means[prev_label] += (img[point] - region_means[prev_label])/(region_pix_count[prev_label])
         else
             # Merge segments and assign to this new label
-            union_label = v[1]
+            union_label = v_neigh[1]
             for i in 1:sz
-                union_label = union!(temp_labels, union_label, v[i])
+                union_label = union!(temp_labels, union_label, v_neigh[i])
             end
 
             result[point] = union_label
             region_pix_count[union_label] += 1
             region_means[union_label] += (img[point] - region_means[union_label])/(region_pix_count[union_label])
 
-            # Apply bfs on all points in v to make their label `max_count_label`
             for i in 1:sz
-                if v[i] != union_label
-                    region_pix_count[union_label] += region_pix_count[v[i]]
-                    region_means[union_label] += (region_means[v[i]] - region_means[union_label])*region_pix_count[v[i]]/region_pix_count[union_label]
+                if v_neigh[i] != union_label
+                    region_pix_count[union_label] += region_pix_count[v_neigh[i]]
+                    region_means[union_label] += (region_means[v_neigh[i]] - region_means[union_label])*region_pix_count[v_neigh[i]]/region_pix_count[union_label]
 
-                    # Remove label result[i] from region_means, region_pix_count
-                    delete!(region_pix_count,v[i])
-                    delete!(region_means,v[i])
+                    # Remove label v_neigh[i] from region_means, region_pix_count
+                    delete!(region_pix_count,v_neigh[i])
+                    delete!(region_means,v_neigh[i])
                 end
             end
         end

--- a/src/region_growing.jl
+++ b/src/region_growing.jl
@@ -1,5 +1,5 @@
 
-default_diff_fn{CT1<:Colorant, CT2<:Colorant}(c1::CT1,c2::CT2) = sqrt(sum(abs2,(c1)-Images.accum(CT2)(c2)))
+default_diff_fn{CT1<:Union{Colorant,Real}, CT2<:Union{Colorant,Real}}(c1::CT1,c2::CT2) = sqrt(sum(abs2,(c1)-Images.accum(CT2)(c2)))
 
 """
     seg_img = seeded_region_growing(img, seeds, [kernel_dim], [diff_fn])
@@ -198,9 +198,9 @@ function seeded_region_growing{CT<:Colorant, N}(img::AbstractArray{CT,N}, seeds:
                 end
             end
         end
-    
+
     end
-    
+
     c0 = count(i->(i==0),result)
     if c0 != 0
         push!(labels, 0)
@@ -258,8 +258,8 @@ function unseeded_region_growing{CT<:Colorant, N}(img::AbstractArray{CT,N}, thre
 end
 
 function unseeded_region_growing{CT<:Colorant,N}(img::AbstractArray{CT,N}, threshold::Real, neighbourhood::Function, diff_fn = default_diff_fn)
-   
-    # Required data structures 
+
+    # Required data structures
     result                  =   similar(dims->fill(-1,dims), indices(img))      # Array to store labels
     neighbours              =   PriorityQueue(CartesianIndex{N}, Float64)       # Priority Queue containing boundary pixels with δ as the priority
     region_means            =   Dict{Int, Images.accum(CT)}()                   # A map containing (label, mean) pairs
@@ -279,7 +279,7 @@ function unseeded_region_growing{CT<:Colorant,N}(img::AbstractArray{CT,N}, thres
             enqueue!(neighbours, p, diff_fn(region_means[result[start_point]], img[p]))
         end
     end
-    
+
     while !isempty(neighbours)
         point = dequeue!(neighbours)
         δ = Inf

--- a/test/fast_scanning.jl
+++ b/test/fast_scanning.jl
@@ -83,4 +83,24 @@
   @test all(label->(expected_means[label] ≈ seg.segment_means[label]), seg.segment_labels)
   @test seg.image_indexmap == expected
 
+  # Adaptive Thresholding
+  img = [ 0.0 0.1 0.7 0.9;
+          0.0 0.1 0.7 0.9;
+          0.2 0.3 0.7 0.9;
+          0.2 0.3 0.7 0.9; ]
+
+  seg = fast_scanning(img, [0.2 0.1; 0.1 0.3])
+  expected =  [ 1 1 4 4;
+                1 1 4 4;
+                2 2 4 4;
+                2 2 4 4; ]
+  expected_labels = [1,2,4];
+  expected_means = Dict(1=>0.05,2=>0.25,4=>0.8)
+  expected_count = Dict(1=>4,2=>4,4=>8)
+
+  @test all(label->(label in expected_labels), seg.segment_labels)
+  @test all(label->(label in seg.segment_labels), expected_labels)
+  @test expected_count == seg.segment_pixel_count
+  @test all(label->(expected_means[label] ≈ seg.segment_means[label]), seg.segment_labels)
+  @test seg.image_indexmap == expected
 end

--- a/test/fast_scanning.jl
+++ b/test/fast_scanning.jl
@@ -1,0 +1,86 @@
+@testset "Fast scanning" begin
+  # 2-D array
+  img = zeros(Float64, 9, 9)
+  img[4:6,:] = 10
+  img[:,4:6] = 11
+
+  seg = fast_scanning(img, 2)
+  expected = fill(4,(9,9))
+  expected[1:3,1:3] = 1
+  expected[1:3,7:9] = 5
+  expected[7:9,1:3] = 3
+  expected[7:9,7:9] = 6
+  expected_labels = [1,3,4,5,6]
+  expected_means = Dict(1=>0.0,3=>0.0,4=>10.6,5=>0.0,6=>0.0)
+  expected_count = Dict(1=>9,3=>9,4=>45,5=>9,6=>9)
+
+  @test all(label->(label in expected_labels), seg.segment_labels)
+  @test all(label->(label in seg.segment_labels), expected_labels)
+  @test expected_count == seg.segment_pixel_count
+  @test all(label->(expected_means[label] ≈ seg.segment_means[label]), seg.segment_labels)
+  @test seg.image_indexmap == expected
+
+  # Offset array
+  img = centered(img)
+
+  seg = fast_scanning(img, 2)
+  expected = centered(expected)
+
+  @test all(label->(label in expected_labels), seg.segment_labels)
+  @test all(label->(label in seg.segment_labels), expected_labels)
+  @test expected_count == seg.segment_pixel_count
+  @test all(label->(expected_means[label] ≈ seg.segment_means[label]), seg.segment_labels)
+  @test seg.image_indexmap == expected
+
+  # 3-D array
+  img = zeros(Float64, (7,7,7))
+  img[3:5,2:6,1:3] = 2
+  img[1:4,5:7,2:6] = 3
+  img[3:5,3:5,3:5] = 8
+
+  seg = fast_scanning(img, 1.5)
+  expected = fill(5, (7,7,7))
+  expected[3:5,2:6,1:3] = expected[1:4,5:7,2:6] = 3
+  expected[3:5,3:5,3:5] = 4
+  expected_labels = [3,4,5]
+  expected_means = Dict(3=>222/84,4=>8.0,5=>0.0)
+  expected_count = Dict(3=>84,4=>27,5=>232)
+
+  @test all(label->(label in expected_labels), seg.segment_labels)
+  @test all(label->(label in seg.segment_labels), expected_labels)
+  @test expected_count == seg.segment_pixel_count
+  @test all(label->(expected_means[label] ≈ seg.segment_means[label]), seg.segment_labels)
+  @test seg.image_indexmap == expected
+
+  # custom diff_fn
+  img = zeros(RGB{N0f8}, (3,3))
+  img[2,:] = RGB{N0f8}(0.2, 0.4, 0.4)
+  img[3,:] = RGB{N0f8}(0.2, 1.0, 1.0)
+
+  seg = fast_scanning(img, 0.22)
+  expected = ones(Int, (3,3))
+  expected[2,:] = 2
+  expected[3,:] = 3
+  expected_labels = [1,2,3]
+  expected_means = Dict(1=>RGB{Float64}(0.0,0.0,0.0),2=>RGB{Float64}(0.2,0.4,0.4),3=>RGB{Float64}(0.2,1.0,1.0))
+  expected_count = Dict(1=>3,2=>3,3=>3)
+
+  @test all(label->(label in expected_labels), seg.segment_labels)
+  @test all(label->(label in seg.segment_labels), expected_labels)
+  @test expected_count == seg.segment_pixel_count
+  @test all(label->(expected_means[label] ≈ seg.segment_means[label]), seg.segment_labels)
+  @test seg.image_indexmap == expected
+
+  seg = fast_scanning(img, 0.22, (i,j)->(abs(i.r-j.r)))
+  expected = ones(Int, (3,3))
+  expected_labels = [1]
+  expected_means = Dict(1=>RGB{Float64}(1.2/9,4.2/9,4.2/9))
+  expected_count = Dict(1=>9)
+
+  @test all(label->(label in expected_labels), seg.segment_labels)
+  @test all(label->(label in seg.segment_labels), expected_labels)
+  @test expected_count == seg.segment_pixel_count
+  @test all(label->(expected_means[label] ≈ seg.segment_means[label]), seg.segment_labels)
+  @test seg.image_indexmap == expected
+
+end

--- a/test/fast_scanning.jl
+++ b/test/fast_scanning.jl
@@ -103,4 +103,19 @@
   @test expected_count == seg.segment_pixel_count
   @test all(label->(expected_means[label] ≈ seg.segment_means[label]), seg.segment_labels)
   @test seg.image_indexmap == expected
+
+  seg = fast_scanning(img, (2,2))
+  expected =  [ 1 3 5 6;
+                1 3 5 6;
+                2 4 5 6;
+                2 4 5 6; ]
+  expected_labels = [1,2,3,4,5,6]
+  expected_means = Dict(1=>0.0,2=>0.2,3=>0.1,4=>0.3,5=>0.7,6=>0.9)
+  expected_count = Dict(1=>2,2=>2,3=>2,4=>2,5=>4,6=>4)
+
+  @test all(label->(label in expected_labels), seg.segment_labels)
+  @test all(label->(label in seg.segment_labels), expected_labels)
+  @test expected_count == seg.segment_pixel_count
+  @test all(label->(expected_means[label] ≈ seg.segment_means[label]), seg.segment_labels)
+  @test seg.image_indexmap == expected
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,3 +2,4 @@ using ImageSegmentation, Images, Base.Test
 
 include("region_growing.jl")
 include("felzenszwalb.jl")
+include("fast_scanning.jl")


### PR DESCRIPTION
An implementation of the fast scanning algorithm as mentioned in [this paper](http://djj.ee.ntu.edu.tw/FastSegment.pdf). An extension of this algorithm has also been implemented for working with higher dimensional images. A few features like removal of small segments and use of adaptive threshold will be progressively added. The performance of this algorithm for 2-d images is fantastic. After addition of the above-mentioned features, I will add the docstring and tests.

Here are a demo:

Original:
![current](https://user-images.githubusercontent.com/15063205/27552221-1aa6b8a6-5ac4-11e7-8b3d-9faa3271e243.png)

After segmentation and coloring the larger segments (except background):
![segmented](https://user-images.githubusercontent.com/15063205/27552241-340b5e00-5ac4-11e7-8d62-e4d67afc765b.png)

Benchmark results:
```julia
julia> summary(img)
"270×400 Array{RGB{N0f8},2}"

julia> @benchmark fast_scanning(img, 0.21)
BenchmarkTools.Trial: 
  memory estimate:  1.94 MiB
  allocs estimate:  5636
  --------------
  minimum time:     20.537 ms (0.00% GC)
  median time:      21.222 ms (0.00% GC)
  mean time:        21.887 ms (0.60% GC)
  maximum time:     40.295 ms (0.00% GC)
  --------------
  samples:          229
  evals/sample:     1

```