### PR TITLE
Added watershed segmentation

### DIFF
--- a/src/ImageSegmentation.jl
+++ b/src/ImageSegmentation.jl
@@ -20,6 +20,7 @@ include("core.jl")
 include("region_growing.jl")
 include("felzenszwalb.jl")
 include("fast_scanning.jl")
+include("watershed.jl")
 
 export
     # methods
@@ -27,6 +28,8 @@ export
     unseeded_region_growing,
     felzenszwalb,
     fast_scanning,
+    watershed,
+    hmin_transform,
 
     # types
     SegmentedImage,

--- a/src/watershed.jl
+++ b/src/watershed.jl
@@ -18,14 +18,14 @@ Parameters:
 -    markers        = an array marking the pixels where flooding should start
 
 """
-function watershed{T<:Images.NumberLike, S<:Integer}(img::AbstractArray{T, 2}, markers::AbstractArray{S,2})
+function watershed{T<:Images.NumberLike, S<:Integer, N}(img::AbstractArray{T, N}, markers::AbstractArray{S,N})
 
     if indices(img) != indices(markers)
         error("image size doesn't match marker image size")
     end
 
     segments = copy(markers)
-    pq = PriorityQueue(CartesianIndex{2}, PixelKey{T}, Base.Order.Forward)
+    pq = PriorityQueue(CartesianIndex{N}, PixelKey{T}, Base.Order.Forward)
     time_step = 0
 
     R = CartesianRange(indices(img))
@@ -60,16 +60,14 @@ function watershed{T<:Images.NumberLike, S<:Integer}(img::AbstractArray{T, 2}, m
     region_means        = Dict{Int, Images.accum(T)}()
     region_pix_count    = Dict{Int, Int}()
 
-    for j in indices(img, 2)
-        for i in indices(img, 1)
-            region_pix_count[segments[i,j]] = get(region_pix_count, segments[i, j], 0) + 1
-            region_means[segments[i,j]] = get(region_means, segments[i,j], zero(Images.accum(T))) + (img[i, j] - get(region_means, segments[i,j], zero(Images.accum(T))))/region_pix_count[segments[i,j]]
-        end
+    for i in R
+        region_pix_count[segments[i]] = get(region_pix_count, segments[i], 0) + 1
+        region_means[segments[i]] = get(region_means, segments[i], zero(Images.accum(T))) + (img[i] - get(region_means, segments[i], zero(Images.accum(T))))/region_pix_count[segments[i]]
     end
     return SegmentedImage(segments, labels, region_means, region_pix_count)
 end
 
-function watershed{T<:Images.NumberLike}(img::AbstractArray{T, 2})
+function watershed{T<:Images.NumberLike, N}(img::AbstractArray{T, N})
     markers = zeros(Int, size(img))
     i = 0
     for j in findlocalminima(img)

--- a/src/watershed.jl
+++ b/src/watershed.jl
@@ -11,7 +11,7 @@ isless{T}(a::PixelKey{T}, b::PixelKey{T}) = (a.val < b.val) || (a.val == b.val &
 segments                = watershed(img, [markers])
 ``` 
 Segments the image using watershed transform. Each basin formed by watershed transform corresponds to a segment.
-If no markers are provided, local minima of the image are taken as markers. If two connected component
+If you are using image local minimas as markers, consider using hmin_transform to avoid oversegmentation.
     
 Parameters:  
 -    img            = input grayscale image
@@ -67,31 +67,13 @@ function watershed{T<:Images.NumberLike, S<:Integer, N}(img::AbstractArray{T, N}
     return SegmentedImage(segments, labels, region_means, region_pix_count)
 end
 
-function watershed{T<:Images.NumberLike, N}(img::AbstractArray{T, N})
-    minimas = ones(Bool, size(img))
-    R = CartesianRange(indices(img))
-    Rinterior = CartesianRange(first(R)+1, last(R)-1)
-
-    for i in Rinterior
-        for j in CartesianRange(i-1, i+1)
-            if img[j] > img[i]
-                minimas[i] = false
-                break
-            end
-        end
-    end
-
-    markers = label_components(minimas)
-    watershed(img, markers)
-end
-
 """
 ```
 out = hmin_transform(img, h)
 ```
+Suppresses all minima in grayscale image whose depth is less than h.  
 
-Suppresses all minima in grayscale image whose depth is less than h.
-H-minima transform is defined as the reconstruction by erosion of (img + h) by img.
+H-minima transform is defined as the reconstruction by erosion of (img + h) by img. See Morphological image analysis by Soille pg 170-172.  
 """
 function hmin_transform{T<:Images.NumberLike}(img::Array{T, 2}, h::Real)
     out = img.+h

--- a/src/watershed.jl
+++ b/src/watershed.jl
@@ -79,7 +79,7 @@ Suppresses all minima in grayscale image whose depth is less than h.
 
 H-minima transform is defined as the reconstruction by erosion of (img + h) by img. See Morphological image analysis by Soille pg 170-172.  
 """
-function hmin_transform{T<:Images.NumberLike}(img::Array{T, N}, h::Real)
+function hmin_transform{T<:Images.NumberLike, N}(img::Array{T, N}, h::Real)
     out = img.+h
     while true
         temp = max.(img, erode(out))

--- a/src/watershed.jl
+++ b/src/watershed.jl
@@ -11,7 +11,7 @@ isless{T}(a::PixelKey{T}, b::PixelKey{T}) = (a.val < b.val) || (a.val == b.val &
 segments                = watershed(img, [markers])
 ``` 
 Segments the image using watershed transform. Each basin formed by watershed transform corresponds to a segment.
-If no markers are provided, local minima of the image are taken as markers.
+If no markers are provided, local minima of the image are taken as markers. If two connected component
     
 Parameters:  
 -    img            = input grayscale image
@@ -68,12 +68,20 @@ function watershed{T<:Images.NumberLike, S<:Integer, N}(img::AbstractArray{T, N}
 end
 
 function watershed{T<:Images.NumberLike, N}(img::AbstractArray{T, N})
-    markers = zeros(Int, size(img))
-    i = 0
-    for j in findlocalminima(img)
-        i += 1
-        markers[j] = i
+    minimas = ones(Bool, size(img))
+    R = CartesianRange(indices(img))
+    Rinterior = CartesianRange(first(R)+1, last(R)-1)
+
+    for i in Rinterior
+        for j in CartesianRange(i-1, i+1)
+            if img[j] > img[i]
+                minimas[i] = false
+                break
+            end
+        end
     end
+
+    markers = label_components(minimas)
     watershed(img, markers)
 end
 
@@ -83,19 +91,17 @@ out = hmin_transform(img, h)
 ```
 
 Suppresses all minima in grayscale image whose depth is less than h.
-
 H-minima transform is defined as the reconstruction by erosion of (img + h) by img.
 """
 function hmin_transform{T<:Images.NumberLike}(img::Array{T, 2}, h::Real)
-    img2 = img.+h
-    out = similar(img)
+    out = img.+h
     while true
-        out = max.(img, erode(img2))
-        if out == img2
+        temp = max.(img, erode(out))
+        if temp == out
             break
         end
-        img2 = out
+        out = temp
     end
-    return img2
+    return out
 end
 

--- a/src/watershed.jl
+++ b/src/watershed.jl
@@ -42,7 +42,7 @@ function watershed{T<:Images.NumberLike, S<:Integer, N}(img::AbstractArray{T, N}
         end
     end
 
-    while !isempty(pq) > 0
+    while !isempty(pq)
         current = dequeue!(pq)
         segments_current = segments[current]
         img_current = img[current]

--- a/src/watershed.jl
+++ b/src/watershed.jl
@@ -1,0 +1,97 @@
+import Base.isless
+
+immutable PixelKey{CT}
+    val::CT
+    time_step::Int
+end
+isless{T}(a::PixelKey{T}, b::PixelKey{T}) = (a.val < b.val) || (a.val == b.val && a.time_step < b.time_step)
+
+"""
+```
+segments                = watershed(img, [markers])
+``` 
+Segments the image using watershed transform. Each basin formed by watershed transform corresponds to a segment.
+If no markers are provided, local minima of the image are taken as markers.
+    
+Parameters:  
+-    img            = input grayscale image
+-    markers        = an array marking the pixels where flooding should start
+
+"""
+function watershed{T<:Images.NumberLike}(img::Array{T, 2}, markers::Array{T,2})
+
+    segments = copy(markers)
+    pq = PriorityQueue(CartesianIndex{2}, PixelKey{T}, Base.Order.Forward)
+    time_step = 0
+
+    R = CartesianRange(size(img))
+    Istart, Iend = first(R), last(R)
+    for i in CartesianRange(size(img))
+        if markers[i] > 0
+            for j in CartesianRange(max(Istart,i-1), min(i+1,Iend))
+                if segments[j] == 0
+                    segments[j] = markers[i]
+                    enqueue!(pq, j, PixelKey(img[i], time_step))
+                    time_step += 1
+                end
+            end
+        end
+    end
+
+    while length(pq) > 0
+        current = dequeue!(pq)
+        for j in CartesianRange(max(Istart,current-1), min(current+1,Iend))
+            if segments[j] == 0
+                segments[j] = segments[current]
+                enqueue!(pq, j, PixelKey(img[current], time_step))
+                time_step += 1
+            end
+        end
+    end
+
+    num_segments        = Int(maximum(segments))
+    labels              = Array(1:num_segments)
+    region_means        = Dict{Int, Images.accum(T)}()
+    region_pix_count    = Dict{Int, Int}()
+
+    for j in indices(img, 2)
+        for i in indices(img, 1)
+            region_pix_count[segments[i,j]] = get(region_pix_count, segments[i, j], 0) + 1
+            region_means[segments[i,j]] = get(region_means, segments[i,j], zero(Images.accum(T))) + (img[i, j] - get(region_means, segments[i,j], zero(Images.accum(T))))/region_pix_count[segments[i,j]]
+        end
+    end
+    return SegmentedImage(segments, labels, region_means, region_pix_count)
+end
+
+function watershed{T<:Images.NumberLike}(img::Array{T, 2})
+    markers = zeros(img)
+    i = 0
+    for i in findlocalmaxima(accumulator_matrix)
+        i += 1
+        markers[i] = i
+    end
+    watershed(img, markers)
+end
+
+"""
+```
+out = hmin_transform(img, h)
+```
+
+Suppresses all minima in grayscale image whose depth is less than h.
+
+H-minima transform is defined as the reconstruction by erosion of (img + h) by img.
+"""
+function hmin_transform{T<:Images.NumberLike}(img::Array{T, 2}, h::Real)
+    img2 = img.+h
+    out = similar(img)
+    while true
+        out = max.(img, erode(img2))
+        if out == img2
+            break
+        end
+        img2 = out
+    end
+    return img2
+end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,3 +3,4 @@ using ImageSegmentation, Images, Base.Test
 include("region_growing.jl")
 include("felzenszwalb.jl")
 include("fast_scanning.jl")
+include("watershed.jl")

--- a/test/watershed.jl
+++ b/test/watershed.jl
@@ -17,5 +17,18 @@ using ImageFiltering
     @test result.segment_labels == collect(1:2)
     @test all(label->(label==result.image_indexmap[50,50]), result.image_indexmap[26:74,26:74])
 
-    # To do: Add more tests
+
+    img = ones(15, 15)
+    #minima of height 0.2
+    img[3:5, 3:5] = 0.9
+    img[4,4] = 0.8
+    #minima of height 0.7
+    img[9:13, 9:13] = 0.8
+    img[10:12, 10:12] = 0.7
+    img[11,11] = 0.3
+
+    out = hmin_transform(img, 0.25)
+
+    @test findlocalminima(img) == [CartesianIndex(4, 4), CartesianIndex(11, 11)]
+    @test findlocalminima(out) == [CartesianIndex(11, 11)] 
 end

--- a/test/watershed.jl
+++ b/test/watershed.jl
@@ -19,10 +19,10 @@ using ImageFiltering
 
 
     img = ones(15, 15)
-    #minima of height 0.2
+    #minima of depth 0.2
     img[3:5, 3:5] = 0.9
     img[4,4] = 0.8
-    #minima of height 0.7
+    #minima of depth 0.7
     img[9:13, 9:13] = 0.8
     img[10:12, 10:12] = 0.7
     img[11,11] = 0.3

--- a/test/watershed.jl
+++ b/test/watershed.jl
@@ -3,12 +3,11 @@ using ImageFiltering
 @testset "watershed" begin
     
     img = zeros(100, 100)
-    img = zeros(Float64, (100,100))
     img[25:75, 25:75] = 1
 
     img, _ = magnitude_phase(img)
 
-    markers = zeros(img)
+    markers = zeros(Int, size(img))
     markers[1, 1] = 1
     markers[50, 50] = 2
 

--- a/test/watershed.jl
+++ b/test/watershed.jl
@@ -1,0 +1,22 @@
+using ImageFiltering
+
+@testset "watershed" begin
+    
+    img = zeros(100, 100)
+    img = zeros(Float64, (100,100))
+    img[25:75, 25:75] = 1
+
+    img, _ = magnitude_phase(img)
+
+    markers = zeros(img)
+    markers[1, 1] = 1
+    markers[50, 50] = 2
+
+    result = watershed(img, markers)
+
+    @test length(result.segment_labels) == 2
+    @test result.segment_labels == collect(1:2)
+    @test all(label->(label==result.image_indexmap[50,50]), result.image_indexmap[26:74,26:74])
+
+    # To do: Add more tests
+end


### PR DESCRIPTION
Implements watershed transformation based image segmentation.

The algorithm considers a grayscale image as a topographic surface. This surface is flooded from the marker positions (local minima of the image by default) and final basins correspond to the segments. (Nicely explained [here](http://cmm.ensmp.fr/~beucher/wtshed.html)).

The basic version often produces over-segmentation due to noise and too many local minima. There are several strategies to deal with this - preprocessing the image to remove shallow(insignificant) minima, flooding the surface from predefined markers and post processing the image to merge similar regions.