### PR TITLE
Some necessary functions for RAG and removing small segments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,7 @@ after_success:
   - julia -e 'cd(Pkg.dir("ImageSegmentation")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
   # push coverage results to Codecov
   - julia -e 'cd(Pkg.dir("ImageSegmentation")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+
+matrix:
+  allow_failures:
+    - julia: nightly

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,7 @@
 julia 0.6
 Images 0.9
+ImageFiltering 0.1.4
 DataStructures 0.5.3
+StaticArrays 0.6.0
+LightGraphs 0.9.2
+SimpleWeightedGraphs 0.0.1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,3 +32,8 @@ build_script:
 
 test_script:
   - C:\projects\julia\bin\julia -e "Pkg.test(\"ImageSegmentation\")"
+
+matrix:
+  allow_failures:
+    - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
+    - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"

--- a/src/ImageSegmentation.jl
+++ b/src/ImageSegmentation.jl
@@ -2,7 +2,7 @@ __precompile__()
 
 module ImageSegmentation
 
-using Images, DataStructures, StaticArrays, ImageFiltering, LightGraphs
+using Images, DataStructures, StaticArrays, ImageFiltering, LightGraphs, SimpleWeightedGraphs
 
 # For efficient hashing of CartesianIndex
 if !isdefined(Base.IteratorsMD, :cartindexhash_seed)
@@ -31,10 +31,12 @@ export
     watershed,
     hmin_transform,
     region_adjacency_graph,
+    rem_segment,
+    rem_segment!,
+    prune_segments,
 
     # types
     SegmentedImage,
-    ImageEdge,
-    RegionAdjacencyGraph
+    ImageEdge
 
 end # module

--- a/src/ImageSegmentation.jl
+++ b/src/ImageSegmentation.jl
@@ -2,7 +2,7 @@ __precompile__()
 
 module ImageSegmentation
 
-using Images, DataStructures, StaticArrays, ImageFiltering
+using Images, DataStructures, StaticArrays, ImageFiltering, LightGraphs
 
 # For efficient hashing of CartesianIndex
 if !isdefined(Base.IteratorsMD, :cartindexhash_seed)
@@ -30,9 +30,11 @@ export
     fast_scanning,
     watershed,
     hmin_transform,
+    region_adjacency_graph,
 
     # types
     SegmentedImage,
-    ImageEdge
+    ImageEdge,
+    RegionAdjacencyGraph
 
 end # module

--- a/src/core.jl
+++ b/src/core.jl
@@ -19,3 +19,51 @@ immutable ImageEdge
     index2::Int
     weight::Float64
 end
+
+immutable RegionAdjacencyGraph
+    edges::Vector{ImageEdge}
+    vertices::Vector{Int}
+end
+
+function neighbor_regions{T<:SegmentedImage}(s::T, I::CartesianIndex, visited::AbstractArray, n::Set{Int})
+    R = CartesianRange(size(s.image_indexmap))
+    I1, Iend = first(R), last(R)
+    t = Stack(CartesianIndex{2})
+    push!(t, I)
+
+    while !isempty(t)
+        temp = pop!(t)
+        visited[temp] = true
+        for J in CartesianRange(max(I1, temp-I1), min(Iend, temp+I1))
+            if s.image_indexmap[temp] != s.image_indexmap[J]
+                push!(n,s.image_indexmap[J])
+            elseif !visited[J]
+                push!(t,J)
+            end
+        end
+    end
+    n
+end
+
+function region_adjacency_graph{T<:SegmentedImage}(s::T, weight_fn::Function = default_diff_fn)
+
+    visited = similar(dims->fill(false,dims), indices(s.image_indexmap))
+    G = RegionAdjacencyGraph()
+
+    for p in CartesianRange(indices(s.image_indexmap))
+        local n = Set{Int}()
+        if !visited[p]
+            neighbor_regions(s, p, visited, n)
+            for i in n
+                push!(G, ImageEdge(s.image_indexmap[p], i, weight_fn(s.segment_means[s.image_indexmap[p]], s.segment_means[i])))
+            end
+        end
+    end
+    G
+end
+
+function merge_regions{T<:SegmentedImage}(s::T, thres::Real, diff_fn::Function = default_diff_fn)
+
+    G = region_adjacency_graph(s, diff_fn)
+
+end

--- a/src/core.jl
+++ b/src/core.jl
@@ -20,50 +20,156 @@ immutable ImageEdge
     weight::Float64
 end
 
-immutable RegionAdjacencyGraph
-    edges::Vector{ImageEdge}
-    vertices::Vector{Int}
-end
+"""
+    G, vert_map = region_adjacency_graph(seg, [weight_fn])
 
-function neighbor_regions{T<:SegmentedImage}(s::T, I::CartesianIndex, visited::AbstractArray, n::Set{Int})
-    R = CartesianRange(size(s.image_indexmap))
-    I1, Iend = first(R), last(R)
-    t = Stack(CartesianIndex{2})
-    push!(t, I)
+Constructs a region adjacency graph from the `SegmentedImage`. It returns the RAG
+along with a label->vertex map. Optionally, a weight function `weight_fn` might be
+provided to set the edge weights. `weight_fn` takes two segment means and returns
+the weight of the connecting edge.
 
-    while !isempty(t)
-        temp = pop!(t)
-        visited[temp] = true
-        for J in CartesianRange(max(I1, temp-I1), min(Iend, temp+I1))
-            if s.image_indexmap[temp] != s.image_indexmap[J]
-                push!(n,s.image_indexmap[J])
-            elseif !visited[J]
-                push!(t,J)
-            end
-        end
-    end
-    n
-end
-
+"""
 function region_adjacency_graph{T<:SegmentedImage}(s::T, weight_fn::Function = default_diff_fn)
 
-    visited = similar(dims->fill(false,dims), indices(s.image_indexmap))
-    G = RegionAdjacencyGraph()
+    function neighbor_regions!{T<:SegmentedImage}(s::T, I::CartesianIndex, visited::AbstractArray, n::Set{Int})
+        R = CartesianRange(indices(s.image_indexmap))
+        I1, Iend = first(R), last(R)
+        t = Vector{CartesianIndex{ndims(visited)}}()
+        push!(t, I)
 
+        while !isempty(t)
+            temp = pop!(t)
+            visited[temp] = true
+            for J in CartesianRange(max(I1, temp-I1), min(Iend, temp+I1))
+                if s.image_indexmap[temp] != s.image_indexmap[J]
+                    push!(n,s.image_indexmap[J])
+                elseif !visited[J]
+                    push!(t,J)
+                end
+            end
+        end
+        n
+    end
+
+    local visited   = similar(dims->fill(false,dims), indices(s.image_indexmap))    # Array to mark the pixels that are already visited
+    G               = SimpleWeightedGraph()                                         # The region_adjacency_graph
+    vert_map        = Dict{Int,Int}()                                               # Map that stores (label, vertex) pairs
+
+    # add vertices to graph
+    add_vertices!(G,length(s.segment_labels))
+
+    # setup `vert_map`
+    for (i,l) in enumerate(s.segment_labels)
+        vert_map[l] = i
+    end
+
+    # add edges to graph
     for p in CartesianRange(indices(s.image_indexmap))
-        local n = Set{Int}()
         if !visited[p]
-            neighbor_regions(s, p, visited, n)
+            local n = Set{Int}()
+            neighbor_regions!(s, p, visited, n)
             for i in n
-                push!(G, ImageEdge(s.image_indexmap[p], i, weight_fn(s.segment_means[s.image_indexmap[p]], s.segment_means[i])))
+                add_edge!(G, vert_map[s.image_indexmap[p]], vert_map[i], weight_fn(s.segment_means[s.image_indexmap[p]], s.segment_means[i]))
             end
         end
     end
-    G
+    G, vert_map
 end
 
-function merge_regions{T<:SegmentedImage}(s::T, thres::Real, diff_fn::Function = default_diff_fn)
 
-    G = region_adjacency_graph(s, diff_fn)
+"""
+    new_seg = remove_segment(seg, label, [weight_fn])
+
+Removes the segment having label `label` and returns the new `SegmentedImage`.
+For more info, see [`remove_segment!`](@ref)
+
+"""
+rem_segment{T<:SegmentedImage}(s::T, args...) = rem_segment!(deepcopy(s), args...)
+
+"""
+    remove_segment!(seg, label, [weight_fn])
+
+Removes the segment having label `label` in place, replacing it with the neighboring
+segment having largest pixel count.
+
+"""
+function rem_segment!{T<:SegmentedImage}(s::T, label::Int, weight_fn::Function = default_diff_fn)
+    haskey(s.segment_means, label) || error("Label $label not present!")
+    G, vert_map = region_adjacency_graph(s, weight_fn)
+    vert_label = vert_map[label]
+    neigh = neighbors(G, vert_label)
+
+    maxc = first(neigh)
+    maxc_label = s.segment_labels[maxc]
+    for i in neigh
+        if s.segment_pixel_count[maxc_label] < s.segment_pixel_count[s.segment_labels[i]]
+            maxc = i
+            maxc_label = s.segment_labels[i]
+        end
+    end
+
+    vert_map[label] = maxc
+
+    s.segment_pixel_count[maxc_label] += s.segment_pixel_count[label]
+    s.segment_means[maxc_label] += (s.segment_means[label] - s.segment_means[maxc_label])*s.segment_pixel_count[label]/s.segment_pixel_count[maxc_label]
+
+    for i in CartesianRange(indices(s.image_indexmap))
+        s.image_indexmap[i] = s.segment_labels[vert_map[s.image_indexmap[i]]]
+    end
+
+    delete!(s.segment_means, label)
+    delete!(s.segment_pixel_count, label)
+    deleteat!(s.segment_labels, vert_label)
+
+    s
+end
+
+"""
+    new_seg = prune_segments(seg, thres, [weight_fn])
+
+Removes all segments having pixel count < `thres` replacing them with their neighbouring
+segment having largest pixel count.
+
+"""
+
+function prune_segments{T<:SegmentedImage}(s::T, thres::Int, weight_fn::Function = default_diff_fn)
+
+    G, vert_map = region_adjacency_graph(s, weight_fn)
+    u = IntDisjointSets(nv(G))
+    for v in vertices(G)
+        if s.segment_pixel_count[s.segment_labels[v]] < thres
+            neigh = neighbors(G, v)
+            maxc = first(neigh)
+            for i in neigh
+                if s.segment_pixel_count[s.segment_labels[i]] > s.segment_pixel_count[s.segment_labels[maxc]]
+                    maxc = i
+                end
+            end
+            union!(u, maxc, v)
+        end
+    end
+
+    segments = Set{Int}()
+    for i in 1:nv(G)
+        push!(segments, find_root(u, i))
+    end
+
+    result              =   similar(s.image_indexmap)
+    labels              =   Vector{Int}()
+    region_means        =   similar(s.segment_means)
+    region_pix_count    =   Dict{Int, Int}()
+
+    m_type = eltype(values(region_means))
+
+    for i in segments
+        push!(labels, i)
+    end
+
+    for p in CartesianRange(indices(result))
+        result[p] = find_root(u, vert_map[s.image_indexmap[p]])
+        region_pix_count[result[p]] = get(region_pix_count, result[p], 0) + 1
+        region_means[result[p]] = get(region_means, result[p], zero(m_type)) + (s.segment_means[s.image_indexmap[p]] - get(region_means, result[p], zero(m_type)))/(region_pix_count[result[p]])
+    end
+    SegmentedImage(result, labels, region_means, region_pix_count)
 
 end

--- a/src/fast_scanning.jl
+++ b/src/fast_scanning.jl
@@ -65,9 +65,8 @@ function fast_scanning{CT<:Union{Colorant,Real},N}(img::AbstractArray{CT,N}, thr
 
     # Neighbourhood function
     _diagmN = diagm([1 for i in 1:N])
-    half_region = ntuple(i-> CartesianIndex{N}(ntuple(j->_diagmN[j,i], Val{N})), Val{N})
-    n_gen(region) = x -> ntuple(i-> x-region[i], Val{N})
-    neighbourhood = n_gen(half_region)
+    half_region::NTuple{N,CartesianIndex{N}} = ntuple(i-> CartesianIndex{N}(ntuple(j->_diagmN[j,i], Val{N})), Val{N})
+    neighbourhood(x) = ntuple(i-> x-half_region[i], Val{N})
 
     # Required data structures
     result              =   similar(dims->fill(-1,dims), indices(img))      # Array to store labels
@@ -85,7 +84,7 @@ function fast_scanning{CT<:Union{Colorant,Real},N}(img::AbstractArray{CT,N}, thr
         for p in neighbourhood(point)
             if checkbounds(Bool, img, p)
                 root_p = find_root(temp_labels, result[p])
-                            if diff_fn(region_means[root_p], img[point]) < getscalar(threshold, point, block_length)
+                if diff_fn(region_means[root_p], img[point]) < getscalar(threshold, point, block_length)
                     if prev_label == 0
                         prev_label = root_p
                     elseif prev_label != root_p

--- a/test/core.jl
+++ b/test/core.jl
@@ -1,0 +1,90 @@
+@testset "core" begin
+
+  # RAG
+  img = fill(1.0, (10,10))
+  img[:, 5:10] = 2.0
+  seg = fast_scanning(img, 0.5)
+  g, vm = region_adjacency_graph(seg, (i,j)->sum(abs2, seg.segment_means[i]-seg.segment_means[j]))
+
+  expectedg = SimpleWeightedGraph(2)
+  add_edge!(expectedg, 1, 2, 1.0)
+  expectedvm = Dict(1=>1, 2=>2)
+
+  @test g == expectedg
+  @test vm == expectedvm
+
+  img = fill(1.0, (10,10))
+  img[3:8,3:8] = 2.0
+  img[5:7,5:7] = 3.0
+  seg = fast_scanning(img, 0.5)
+  g, vm = region_adjacency_graph(seg, (i,j)->1)
+
+  expectedg = SimpleWeightedGraph(3)
+  add_edge!(expectedg,1,2)
+  add_edge!(expectedg,2,3)
+  expectedvm = Dict(1=>1, 2=>2, 3=>3)
+
+  @test g == expectedg
+  @test vm == expectedvm
+
+  # rem_segment
+  img = fill(1.0, (10,10))
+  img[1:4,:] = 2.0
+  img[:,5:10] = 4.0
+  seg = fast_scanning(img, 0.5)
+  new_seg = rem_segment(seg, 1, (i,j)->(-seg.segment_pixel_count[j]))
+
+  expected = fill(3, (10,10))
+  expected[5:10,1:4] = 2
+  expected_labels = [2,3]
+  expected_means = Dict(2=>1.0, 3=>68/19)
+  expected_count = Dict(2=>24, 3=>76)
+
+  @test all(label->(label in expected_labels), new_seg.segment_labels)
+  @test all(label->(label in new_seg.segment_labels), expected_labels)
+  @test expected_count == new_seg.segment_pixel_count
+  @test all(label->(expected_means[label] ≈ new_seg.segment_means[label]), new_seg.segment_labels)
+  @test new_seg.image_indexmap == expected
+
+  new_seg = rem_segment(seg, 1, (i,j)->sum(abs2, seg.segment_means[i]-seg.segment_means[j]))
+
+  expected = fill(3,(10,10))
+  expected[:,1:4] = 2
+  expected_means = Dict(2=>1.4, 3=>4.0)
+  expected_count = Dict(2=>40, 3=>60)
+
+  @test all(label->(label in expected_labels), new_seg.segment_labels)
+  @test all(label->(label in new_seg.segment_labels), expected_labels)
+  @test expected_count == new_seg.segment_pixel_count
+  @test all(label->(expected_means[label] ≈ new_seg.segment_means[label]), new_seg.segment_labels)
+  @test new_seg.image_indexmap == expected
+
+  rem_segment!(seg, 1, (i,j)->sum(abs2, seg.segment_means[i]-seg.segment_means[j]))
+
+  @test all(label->(label in expected_labels), seg.segment_labels)
+  @test all(label->(label in seg.segment_labels), expected_labels)
+  @test expected_count == seg.segment_pixel_count
+  @test all(label->(expected_means[label] ≈ seg.segment_means[label]), seg.segment_labels)
+  @test seg.image_indexmap == expected
+
+  # prune_segments
+  img = fill(1.0,(10,10))
+  img[3,3] = 2.0
+  img[5,5] = 2.0
+  img[8:9,7:8] = 3.0
+  seg = fast_scanning(img, 0.5)
+  new_seg = prune_segments(seg, 2, (i,j)->sum(abs2, seg.segment_means[i]-seg.segment_means[j]))
+
+  expected = fill(1,(10,10))
+  expected[8:9,7:8] = 4
+  expected_labels = [1,4]
+  expected_means = Dict(4=>3.0,1=>49/48)
+  expected_count = Dict(4=>4,1=>96)
+
+  @test all(label->(label in expected_labels), new_seg.segment_labels)
+  @test all(label->(label in new_seg.segment_labels), expected_labels)
+  @test expected_count == new_seg.segment_pixel_count
+  @test all(label->(expected_means[label] ≈ new_seg.segment_means[label]), new_seg.segment_labels)
+  @test new_seg.image_indexmap == expected
+
+end

--- a/test/core.jl
+++ b/test/core.jl
@@ -48,7 +48,7 @@
 
   new_seg = rem_segment(seg, 1, (i,j)->sum(abs2, seg.segment_means[i]-seg.segment_means[j]))
 
-  expected = fill(3,(10,10))
+  expected = fill(3, (10,10))
   expected[:,1:4] = 2
   expected_means = Dict(2=>1.4, 3=>4.0)
   expected_count = Dict(2=>40, 3=>60)
@@ -68,18 +68,26 @@
   @test seg.image_indexmap == expected
 
   # prune_segments
-  img = fill(1.0,(10,10))
+  img = fill(1.0, (10,10))
   img[3,3] = 2.0
   img[5,5] = 2.0
   img[8:9,7:8] = 3.0
   seg = fast_scanning(img, 0.5)
-  new_seg = prune_segments(seg, 2, (i,j)->sum(abs2, seg.segment_means[i]-seg.segment_means[j]))
+  new_seg = prune_segments(seg, l->(seg.segment_pixel_count[l] < 2), (i,j)->sum(abs2, seg.segment_means[i]-seg.segment_means[j]))
 
-  expected = fill(1,(10,10))
+  expected = fill(1, (10,10))
   expected[8:9,7:8] = 4
   expected_labels = [1,4]
-  expected_means = Dict(4=>3.0,1=>49/48)
-  expected_count = Dict(4=>4,1=>96)
+  expected_means = Dict(4=>3.0, 1=>49/48)
+  expected_count = Dict(4=>4, 1=>96)
+
+  @test all(label->(label in expected_labels), new_seg.segment_labels)
+  @test all(label->(label in new_seg.segment_labels), expected_labels)
+  @test expected_count == new_seg.segment_pixel_count
+  @test all(label->(expected_means[label] ≈ new_seg.segment_means[label]), new_seg.segment_labels)
+  @test new_seg.image_indexmap == expected
+
+  new_seg = prune_segments(seg, [2,3], (i,j)->sum(abs2, seg.segment_means[i]-seg.segment_means[j]))
 
   @test all(label->(label in expected_labels), new_seg.segment_labels)
   @test all(label->(label in new_seg.segment_labels), expected_labels)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
-using ImageSegmentation, Images, Base.Test
+using ImageSegmentation, Images, Base.Test, SimpleWeightedGraphs, LightGraphs
 
+include("core.jl")
 include("region_growing.jl")
 include("felzenszwalb.jl")
 include("fast_scanning.jl")


### PR DESCRIPTION
The following functions have been added:
* `region_adjacency_graph` : Create an RAG (`SimpleWeightedGraph`) from a `SegmentedImage`
* `rem_segments!` : Similar to `rem_edges!` in `LightGraphs.jl`. It removes a segment replacing it with its neighbor having largest pixel count. The removal is done in place.
* `rem_segment` : Similar to `rem_segments!` but the removal is done on a copy of the `SegmentedImage`.
* `prune_segments` : Removes all segments having pixel count < `thres`. It is much more efficient than calling `rem_segment` for individual segments.

All these functions have been verified to be working on N-d `SegmentedImage`.
For 512x512 color images, `region_adjaceny_graph` takes ~50ms and others take ~100ms.
Tests will be added soon.

There is also a performance fix for `fast_scanning`.