### PR TITLE
Region splitting

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -5,3 +5,4 @@ DataStructures 0.5.3
 StaticArrays 0.6.0
 LightGraphs 0.9.2
 SimpleWeightedGraphs 0.0.1
+RegionTrees 0.1.0

--- a/src/ImageSegmentation.jl
+++ b/src/ImageSegmentation.jl
@@ -2,7 +2,7 @@ __precompile__()
 
 module ImageSegmentation
 
-using Images, DataStructures, StaticArrays, ImageFiltering, LightGraphs, SimpleWeightedGraphs
+using Images, DataStructures, StaticArrays, ImageFiltering, LightGraphs, SimpleWeightedGraphs, RegionTrees
 
 # For efficient hashing of CartesianIndex
 if !isdefined(Base.IteratorsMD, :cartindexhash_seed)
@@ -21,6 +21,7 @@ include("region_growing.jl")
 include("felzenszwalb.jl")
 include("fast_scanning.jl")
 include("watershed.jl")
+include("region_merging.jl")
 
 export
     # methods
@@ -34,6 +35,8 @@ export
     rem_segment,
     rem_segment!,
     prune_segments,
+    region_tree,
+    region_splitting,
 
     # types
     SegmentedImage,

--- a/src/core.jl
+++ b/src/core.jl
@@ -174,7 +174,7 @@ function prune_segments(s::SegmentedImage, is_rem::Function, diff_fn::Function)
 
     G, vert_map = region_adjacency_graph(s, (i,j)->1)
     u = IntDisjointSets(nv(G))
-    for v in vertices(G)
+    for v in LightGraphs.vertices(G)
         if is_rem(s.segment_labels[v])
             neigh = neighbors(G, v)
             minc = first(neigh)

--- a/src/fast_scanning.jl
+++ b/src/fast_scanning.jl
@@ -20,6 +20,10 @@ getscalar{T<:Real,N}(A::AbstractArray{T,N}, i::CartesianIndex{N}, block_length::
 
 getscalar(a::Real, i...) = a
 
+getimage(a::AbstractArray) = a
+
+getimage(s::SegmentedImage) = s.image_indexmap
+
 fast_scanning{CT<:Images.NumberLike,N}(img::AbstractArray{CT,N}, block::NTuple{N,Int} =
     ntuple(i->4,Val{N})) = fast_scanning(img, adaptive_thres(img, block))
 

--- a/src/fast_scanning.jl
+++ b/src/fast_scanning.jl
@@ -20,10 +20,6 @@ getscalar{T<:Real,N}(A::AbstractArray{T,N}, i::CartesianIndex{N}, block_length::
 
 getscalar(a::Real, i...) = a
 
-getimage(a::AbstractArray) = a
-
-getimage(s::SegmentedImage) = s.image_indexmap
-
 fast_scanning{CT<:Images.NumberLike,N}(img::AbstractArray{CT,N}, block::NTuple{N,Int} =
     ntuple(i->4,Val{N})) = fast_scanning(img, adaptive_thres(img, block))
 

--- a/src/region_merging.jl
+++ b/src/region_merging.jl
@@ -38,44 +38,44 @@ end
 region_tree{T<:Union{Colorant, Real},N}(img::AbstractArray{T,N}, homogeneous::Function) =
     region_tree!(Cell(SVector(first(CartesianRange(indices(img))).I), SVector(length.(indices(img))), (0.,0)), img, homogeneous)
 
-function region_splitting{T<:Union{Colorant, Real},N}(img::AbstractArray{T,N}, homogeneous::Function)
+function fill_recursive!{N}(seg::SegmentedImage, image_indexmap::AbstractArray{Int,N}, lc::Int, rtree::Cell)::Int
 
-    function fill_recursive!{N}(seg::SegmentedImage, image_indexmap::AbstractArray{Int,N}, lc::Int, rtree::Cell)
-        
-        if *(length.(indices(img))...) == 0
-            return lc
-        end
-
-        if isleaf(rtree)
-            fill!(image_indexmap, lc)
-            push!(seg.segment_labels, lc)
-            seg.segment_means[lc] = rtree.data[1]
-            seg.segment_pixel_count[lc] = rtree.data[2]
-            return lc+1
-        end
-
-        start_ind = first(CartesianRange(indices(image_indexmap))).I
-        end_ind = last(CartesianRange(indices(image_indexmap))).I
-        mid_ind = (start_ind.+end_ind).÷2
-
-        bv = MVector{N,Bool}()
-        rv = MVector{N,UnitRange{Int64}}()
-        for i in 0:2^N-1
-            for j in 0:N-1
-                bv[j+1] = (i>>j)&1
-            end
-            for j in 1:N
-                if bv[j]
-                    rv[j] = mid_ind[j]+1:end_ind[j]
-                else
-                    rv[j] = start_ind[j]:mid_ind[j]
-                end
-            end
-
-            lc = fill_recursive!(seg, view(image_indexmap, rv...), lc, rtree[(Int.(bv) .+ 1)...])
-        end
-        lc
+    if *(length.(indices(image_indexmap))...) == 0
+        return lc
     end
+
+    if isleaf(rtree)
+        fill!(image_indexmap, lc)
+        push!(seg.segment_labels, lc)
+        seg.segment_means[lc] = rtree.data[1]
+        seg.segment_pixel_count[lc] = rtree.data[2]
+        return lc+1
+    end
+
+    start_ind = first(CartesianRange(indices(image_indexmap))).I
+    end_ind = last(CartesianRange(indices(image_indexmap))).I
+    mid_ind = (start_ind.+end_ind).÷2
+
+    bv = MVector{N,Bool}()
+    rv = MVector{N,UnitRange{Int64}}()
+    for i in 0:2^N-1
+        for j in 0:N-1
+            bv[j+1] = (i>>j)&1
+        end
+        for j in 1:N
+            if bv[j]
+                rv[j] = mid_ind[j]+1:end_ind[j]
+            else
+                rv[j] = start_ind[j]:mid_ind[j]
+            end
+        end
+
+        lc = fill_recursive!(seg, view(image_indexmap, rv...), lc, rtree[(Int.(bv) .+ 1)...])
+    end
+    lc
+end
+
+function region_splitting{T<:Union{Colorant, Real},N}(img::AbstractArray{T,N}, homogeneous::Function)
 
     rtree = region_tree(img, homogeneous)
     seg = SegmentedImage(similar(img, Int), Vector{Int}(), Dict{Int, Images.accum(T)}(), Dict{Int, Int}())

--- a/src/region_merging.jl
+++ b/src/region_merging.jl
@@ -3,9 +3,9 @@ makebt(i) = ()
 
 makert(ind::Int, start_ind::NTuple, mid_ind::NTuple, end_ind::NTuple) = ()
 @inline makert(ind::Int, start_ind::NTuple, mid_ind::NTuple, end_ind::NTuple, b::Bool, rest...) =
-    (b?(mid_ind[ind]+1:end_ind[ind]):(start_ind[ind]:mid_ind[ind]), makert(ind+1, start_ind, mid_ind, end_ind, rest...)...)
+    (b ? (mid_ind[ind]+1:end_ind[ind]) : (start_ind[ind]:mid_ind[ind]), makert(ind+1, start_ind, mid_ind, end_ind, rest...)...)
 
-function region_tree!{T<:Union{Colorant, Real},N}(rtree::Cell, img::AbstractArray{T,N}, homogeneous::Function)
+function region_tree!(rtree::Cell, img::AbstractArray{T,N}, homogeneous::Function) where T<:Union{Colorant, Real} where N
 
     if *(length.(indices(img))...) == 0
         return rtree
@@ -39,14 +39,22 @@ all the regions are homogeneous.
 
     b = homogeneous(img)
 
-Returns true if `img` is homogeneous else false
+Returns true if `img` is homogeneous.
+
+# Examples
+
+```jldoctest
+# img is an array with elements of type `Float64`
+julia> homogeneous(img::AbstractArray{T,N}) where {T<:Colorant,N} = -(extrema(img)...)*-1 < Gray{Float64}(0.2);
+julia> t = region_tree(img, homogeneous);
+```
 
 """
 
-region_tree{T<:Union{Colorant, Real},N}(img::AbstractArray{T,N}, homogeneous::Function) =
+region_tree(img::AbstractArray{T,N}, homogeneous::Function) where {T<:Union{Colorant, Real},N} =
     region_tree!(Cell(SVector(first(CartesianRange(indices(img))).I), SVector(length.(indices(img))), (0.,0)), img, homogeneous)
 
-function fill_recursive!{N}(seg::SegmentedImage, image_indexmap::AbstractArray{Int,N}, lc::Int, rtree::Cell)::Int
+function fill_recursive!(seg::SegmentedImage, image_indexmap::AbstractArray{Int,N}, lc::Int, rtree::Cell)::Int where N
 
     if *(length.(indices(image_indexmap))...) == 0
         return lc
@@ -82,11 +90,19 @@ are homogeneous.
 
     b = homogeneous(img)
 
-Returns true if `img` is homogeneous else false
+Returns true if `img` is homogeneous.
+
+# Examples
+
+```jldoctest
+# img is an array with elements of type `Float64`
+julia> homogeneous(img::AbstractArray{T,N}) where {T<:Colorant,N} = -(extrema(img)...)*-1 < Gray{Float64}(0.2);
+julia> seg = region_splitting(img, homogeneous);
+```
 
 """
 
-function region_splitting{T<:Union{Colorant, Real},N}(img::AbstractArray{T,N}, homogeneous::Function)
+function region_splitting(img::AbstractArray{T,N}, homogeneous::Function) where T<:Union{Colorant, Real} where N
     rtree = region_tree(img, homogeneous)
     seg = SegmentedImage(similar(img, Int), Vector{Int}(), Dict{Int, Images.accum(T)}(), Dict{Int, Int}())
     lc = 1

--- a/src/region_merging.jl
+++ b/src/region_merging.jl
@@ -1,0 +1,85 @@
+function region_tree!{T<:Union{Colorant, Real},N}(rtree::Cell, img::AbstractArray{T,N}, homogeneous::Function)
+
+    if *(length.(indices(img))...) == 0
+        return rtree
+    end
+
+    if homogeneous(img)
+        m = mean(img)
+        c = length(linearindices(img))
+        rtree.data = ((m,c))
+        return rtree
+    end
+
+    split!(rtree)
+    start_ind = first(CartesianRange(indices(img))).I
+    end_ind = last(CartesianRange(indices(img))).I
+    mid_ind = (start_ind.+end_ind).÷2
+
+    bv = MVector{N,Bool}()
+    rv = MVector{N,UnitRange{Int64}}()
+    for i in 0:2^N-1
+        for j in 0:N-1
+            bv[j+1] = (i>>j)&1
+        end
+        for j in 1:N
+            if bv[j]
+                rv[j] = mid_ind[j]+1:end_ind[j]
+            else
+                rv[j] = start_ind[j]:mid_ind[j]
+            end
+        end
+
+        region_tree!(rtree[(Int.(bv) .+ 1)...], view(img, rv...), homogeneous)
+    end
+    rtree
+end
+
+region_tree{T<:Union{Colorant, Real},N}(img::AbstractArray{T,N}, homogeneous::Function) =
+    region_tree!(Cell(SVector(first(CartesianRange(indices(img))).I), SVector(length.(indices(img))), (0.,0)), img, homogeneous)
+
+function region_splitting{T<:Union{Colorant, Real},N}(img::AbstractArray{T,N}, homogeneous::Function)
+
+    function fill_recursive!{N}(seg::SegmentedImage, image_indexmap::AbstractArray{Int,N}, lc::Int, rtree::Cell)
+        
+        if *(length.(indices(img))...) == 0
+            return lc
+        end
+
+        if isleaf(rtree)
+            fill!(image_indexmap, lc)
+            push!(seg.segment_labels, lc)
+            seg.segment_means[lc] = rtree.data[1]
+            seg.segment_pixel_count[lc] = rtree.data[2]
+            return lc+1
+        end
+
+        start_ind = first(CartesianRange(indices(image_indexmap))).I
+        end_ind = last(CartesianRange(indices(image_indexmap))).I
+        mid_ind = (start_ind.+end_ind).÷2
+
+        bv = MVector{N,Bool}()
+        rv = MVector{N,UnitRange{Int64}}()
+        for i in 0:2^N-1
+            for j in 0:N-1
+                bv[j+1] = (i>>j)&1
+            end
+            for j in 1:N
+                if bv[j]
+                    rv[j] = mid_ind[j]+1:end_ind[j]
+                else
+                    rv[j] = start_ind[j]:mid_ind[j]
+                end
+            end
+
+            lc = fill_recursive!(seg, view(image_indexmap, rv...), lc, rtree[(Int.(bv) .+ 1)...])
+        end
+        lc
+    end
+
+    rtree = region_tree(img, homogeneous)
+    seg = SegmentedImage(similar(img, Int), Vector{Int}(), Dict{Int, Images.accum(T)}(), Dict{Int, Int}())
+    lc = 1
+    lc = fill_recursive!(seg, seg.image_indexmap, lc, rtree)
+    seg
+end

--- a/src/region_merging.jl
+++ b/src/region_merging.jl
@@ -45,7 +45,11 @@ Returns true if `img` is homogeneous.
 
 ```jldoctest
 # img is an array with elements of type `Float64`
-julia> homogeneous(img::AbstractArray{T,N}) where {T<:Colorant,N} = -(extrema(img)...)*-1 < Gray{Float64}(0.2);
+julia> function homogeneous(img)
+           min, max = extrema(img)
+           max - min < 0.2
+       end
+       
 julia> t = region_tree(img, homogeneous);
 ```
 
@@ -96,7 +100,11 @@ Returns true if `img` is homogeneous.
 
 ```jldoctest
 # img is an array with elements of type `Float64`
-julia> homogeneous(img::AbstractArray{T,N}) where {T<:Colorant,N} = -(extrema(img)...)*-1 < Gray{Float64}(0.2);
+julia> function homogeneous(img)
+           min, max = extrema(img)
+           max - min < 0.2
+       end
+
 julia> seg = region_splitting(img, homogeneous);
 ```
 

--- a/test/region_merging.jl
+++ b/test/region_merging.jl
@@ -1,5 +1,4 @@
-acc_type{T}(a::T) = Images.accum(T)(a);
-homogeneous{T<:Union{Colorant,Real}, N}(i::AbstractArray{T,N}) = (acc_type(maximum(i))-acc_type(minimum(i)) < 1)
+homogeneous(i::AbstractArray{T,N}) where {T<:Union{Colorant,Real}, N} = -(extrema(i)...) == 0
 
 @testset "Region Splitting" begin
 

--- a/test/region_merging.jl
+++ b/test/region_merging.jl
@@ -1,0 +1,59 @@
+acc_type{T}(a::T) = Images.accum(T)(a);
+homogeneous{T<:Union{Colorant,Real}, N}(i::AbstractArray{T,N}) = (acc_type(maximum(i))-acc_type(minimum(i)) < 1)
+
+@testset "Region Splitting" begin
+
+  # 2-d image
+  img = fill(1, (8,8))
+  img[1:4,1:4] = 2
+
+  t = region_tree(img, homogeneous)
+
+  @test t[1,1].data == ((2,16))
+  @test t[1,2].data == ((1,16))
+  @test t[2,1].data == ((1,16))
+  @test t[2,2].data == ((1,16))
+  @test all(isleaf, [t[1,1], t[1,2], t[2,1], t[2,2]])
+
+  seg = region_splitting(img, homogeneous)
+
+  expected = fill(1,(8,8))
+  expected[5:8,1:4] = 2
+  expected[1:4,5:8] = 3
+  expected[5:8,5:8] = 4
+  expected_labels = [1,2,3,4]
+  expected_means = Dict(1=>2, 2=>1, 3=>1, 4=>1)
+  expected_count = Dict(1=>16, 2=>16, 3=>16, 4=>16)
+
+  @test all(label->(label in expected_labels), seg.segment_labels)
+  @test all(label->(label in seg.segment_labels), expected_labels)
+  @test expected_count == seg.segment_pixel_count
+  @test all(label->(expected_means[label] ≈ seg.segment_means[label]), seg.segment_labels)
+  @test seg.image_indexmap == expected
+
+
+  # 3-d image
+  img = fill(1, (4,4,4))
+  img[3:4,3:4,3:4] = 2
+
+  seg = region_splitting(img, homogeneous)
+
+  expected = fill(1,(4,4,4))
+  expected[3:4,1:2,1:2] = 2
+  expected[1:2,3:4,1:2] = 3
+  expected[3:4,3:4,1:2] = 4
+  expected[1:2,1:2,3:4] = 5
+  expected[3:4,1:2,3:4] = 6
+  expected[1:2,3:4,3:4] = 7
+  expected[3:4,3:4,3:4] = 8
+  expected_labels = [1,2,3,4,5,6,7,8]
+  expected_means = Dict(ntuple(i->(i=>1),7)..., 8=>2)
+  expected_count = Dict(ntuple(i->(i=>8), 8)...)
+
+  @test all(label->(label in expected_labels), seg.segment_labels)
+  @test all(label->(label in seg.segment_labels), expected_labels)
+  @test expected_count == seg.segment_pixel_count
+  @test all(label->(expected_means[label] ≈ seg.segment_means[label]), seg.segment_labels)
+  @test seg.image_indexmap == expected
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,8 @@
-using ImageSegmentation, Images, Base.Test, SimpleWeightedGraphs, LightGraphs
+using ImageSegmentation, Images, Base.Test, SimpleWeightedGraphs, LightGraphs, StaticArrays, RegionTrees
 
 include("core.jl")
 include("region_growing.jl")
 include("felzenszwalb.jl")
 include("fast_scanning.jl")
 include("watershed.jl")
+include("region_merging.jl")


### PR DESCRIPTION
Added functions for creating region trees (using `RegionTrees.jl`) and segmenting images using region splitting algorithm. The time complexity of the algorithm is O(n*log(n)). It works for N-dimensional arbitrary indexed images.

Working example:
```julia
using Images, ImageSegmentation, TestImages
img = testimage("camera");
f{T}(a::T) = Images.accum(T)(a);
homogeneous(i::AbstractArray)::Bool = (abs(f(minimum(i))-f(maximum(i))) < 0.2);
seg = region_splitting(img, homogeneous);
```
Original:
![car](https://user-images.githubusercontent.com/15063205/28926244-d82d0122-7884-11e7-8208-38d206639821.png)

RegionTree (threshold = 0.2):
![car_tree](https://user-images.githubusercontent.com/15063205/28926265-e929611e-7884-11e7-822a-63cdae76478a.png)

Segmented Image:
![car_seg](https://user-images.githubusercontent.com/15063205/28926283-f398f3a8-7884-11e7-801c-2b2e87d47864.png)

