### PR TITLE
Clustering based segmentation

### DIFF
--- a/src/ImageSegmentation.jl
+++ b/src/ImageSegmentation.jl
@@ -23,6 +23,7 @@ include("fast_scanning.jl")
 include("watershed.jl")
 include("region_merging.jl")
 include("meanshift.jl")
+include("fuzzy_cmeans.jl")
 
 export
     # methods
@@ -39,7 +40,7 @@ export
     region_tree,
     region_splitting,
     meanshift,
-
+    fuzzy_cmeans,
     # types
     SegmentedImage,
     ImageEdge

--- a/src/ImageSegmentation.jl
+++ b/src/ImageSegmentation.jl
@@ -3,6 +3,7 @@ __precompile__()
 module ImageSegmentation
 
 using Images, DataStructures, StaticArrays, ImageFiltering, LightGraphs, SimpleWeightedGraphs, RegionTrees, Distances, StaticArrays, Clustering
+import Clustering: fuzzy_cmeans
 
 # For efficient hashing of CartesianIndex
 if !isdefined(Base.IteratorsMD, :cartindexhash_seed)

--- a/src/ImageSegmentation.jl
+++ b/src/ImageSegmentation.jl
@@ -3,7 +3,7 @@ __precompile__()
 module ImageSegmentation
 
 using Images, DataStructures, StaticArrays, ImageFiltering, LightGraphs, SimpleWeightedGraphs, RegionTrees, Distances, StaticArrays, Clustering
-import Clustering: fuzzy_cmeans
+import Clustering: kmeans, fuzzy_cmeans
 
 # For efficient hashing of CartesianIndex
 if !isdefined(Base.IteratorsMD, :cartindexhash_seed)
@@ -24,7 +24,7 @@ include("fast_scanning.jl")
 include("watershed.jl")
 include("region_merging.jl")
 include("meanshift.jl")
-include("fuzzy_cmeans.jl")
+include("clustering.jl")
 
 export
     # methods
@@ -41,7 +41,9 @@ export
     region_tree,
     region_splitting,
     meanshift,
+    kmeans,
     fuzzy_cmeans,
+    
     # types
     SegmentedImage,
     ImageEdge

--- a/src/clustering.jl
+++ b/src/clustering.jl
@@ -1,0 +1,13 @@
+function img_to_data(img::AbstractArray{T,N}) where T<:Colorant where N
+    AT = Images.accum(T)
+    aimg = AT.(img)
+    pimg = parent(aimg)
+    ch = channelview(pimg)
+    data = reshape(ch, :, *(size(pimg)...))
+end
+
+kmeans(img::AbstractArray{T,N}, args...; kwargs...) where {T<:Colorant,N} =
+    kmeans(img_to_data(img), args...; kwargs...)
+
+fuzzy_cmeans(img::AbstractArray{T,N}, args...; kwargs...) where {T<:Colorant,N} =
+    fuzzy_cmeans(img_to_data(img), args...; kwargs...)

--- a/src/fuzzy_cmeans.jl
+++ b/src/fuzzy_cmeans.jl
@@ -1,6 +1,0 @@
-function fuzzy_cmeans(img::AbstractArray{T,N}, args...; kwargs...) where T<:Colorant where N
-    pimg = parent(img)
-    ch = channelview(pimg)
-    data = reshape(ch, :, *(size(pimg)...))
-    fuzzy_cmeans(data, args...; kwargs...)
-end

--- a/src/fuzzy_cmeans.jl
+++ b/src/fuzzy_cmeans.jl
@@ -1,0 +1,63 @@
+function update_weights!(weights, arr, centers, fuzziness, norm_fn)
+  pow = 2.0/(fuzziness-1)
+  for i in 1:length(indices(arr)[2])
+    vali = arr[:,i]
+    for j in 1:length(indices(centers)[2])
+      den = 0.0
+      for k in 1:length(indices(centers)[2])
+        den += (norm_fn(vali-centers[:,j])/norm_fn(vali-centers[:,k]))^pow
+      end
+      weights[i,j] = 1.0/den
+    end
+  end
+end
+
+function update_centers!(centers, arr, weights, fuzziness)
+  for j in 1:length(indices(centers)[2])
+    num = fill(0.0, length(indices(arr)[1]))
+    den = 0.0
+    for i in 1:length(indices(arr)[2])
+      δm = weights[i,j]^fuzziness
+      num += δm*arr[:,i]
+      den += δm
+    end
+    centers[:,j] = num/den
+  end
+end
+
+function fuzzy_cmeans{T<:Real}(arr::AbstractArray{T,2}, C::Int, totiter::Int, eps_::Real, fuzziness::Real, norm_fn::Function = norm)
+  weights = rand(Float64, (length(indices(arr)[2]), C))
+  for i in 1:length(indices(arr)[2])
+    s = sum(weights[i,:])
+    weights[i,:] /= s
+  end
+
+  centers = fill(0.0, length(indices(arr)[1]), C)
+  update_centers!(centers, arr, weights, fuzziness)
+
+  δ = Inf
+  iter = 0
+  prev_centers = centers
+
+  while iter < totiter && δ > eps_
+
+    update_centers!(centers, arr, weights, fuzziness)
+    update_weights!(weights, arr, centers, fuzziness, norm_fn)
+    println(prev_centers)
+    println(centers)
+    δ = maximum([norm_fn(prev_centers[:,i] - centers[:,i]) for i in 1:length(indices(centers)[2])])
+    prev_centers = centers
+    iter += 1
+    println(iter,": ",δ)
+  end
+
+  weights, centers
+end
+
+function fuzzy_cmeans{T<:Colorant, N}(img::AbstractArray{T,N}, rest...)
+  ch = channelview(img)
+  n = ndims(ch)
+  pch = permuteddimsview(ch, ntuple(i->i%n+1, n))
+  data = reshape(pch, *(length.(indices(img))...), :)'
+  fuzzy_cmeans(data, rest...)
+end

--- a/src/fuzzy_cmeans.jl
+++ b/src/fuzzy_cmeans.jl
@@ -1,66 +1,6 @@
-function update_weights!(weights, data, centers, fuzziness, dist_metric)
-    pow = 2.0/(fuzziness-1)
-    nrows, ncols = size(weights)
-    dists = pairwise(dist_metric, data, centers)
-    for i in 1:nrows
-        for j in 1:ncols
-            den = 0.0
-            for k in 1:ncols
-                den += (dists[i,j]/dists[i,k])^pow
-            end
-            weights[i,j] = 1.0/den
-        end
-    end
-end
-
-function update_centers!(centers, data, weights, fuzziness)
-    nrows, ncols = size(weights)
-    for j in 1:ncols
-        num = zeros(Float64, size(data[:,1]))
-        den = 0.0
-        for i in 1:nrows
-            δm = weights[i,j]^fuzziness
-            num += δm * data[:,i]
-            den += δm
-        end
-        centers[:,j] = num/den
-    end
-end
-
-function fuzzy_cmeans(data::AbstractArray{T,2}, C::Int, fuzziness::Real, totiter::Int = 100, eps_::Real = 1e-3, dist_metric::Metric = Euclidean(); debug::Bool = false) where T<:Real
-    nrows, ncols = size(data)
-
-    # Initialize weights randomly
-    weights = rand(Float64, ncols, C)
-    weights ./= sum(weights, 2)
-
-    centers = fill(0.0, nrows, C)
-
-    δ = Inf
-    iter = 0
-    prev_centers = identity.(centers)
-
-    if debug
-        prog = ProgressThresh(eps_, "Converging:")
-    end
-
-    while iter < totiter && δ > eps_
-        update_centers!(centers, data, weights, fuzziness)
-        update_weights!(weights, data, centers, fuzziness, dist_metric)
-        δ = maximum(colwise(dist_metric, prev_centers, centers))
-        copy!(prev_centers, centers)
-        iter += 1
-        if debug
-            ProgressMeter.update!(prog, δ, showvalues = [(:Iteration, iter)])
-        end
-    end
-
-    weights, centers
-end
-
-function fuzzy_cmeans(img::AbstractArray{T,N}, rest...; debug::Bool = false) where T<:Colorant where N
+function fuzzy_cmeans(img::AbstractArray{T,N}, args...; kwargs...) where T<:Colorant where N
     pimg = parent(img)
     ch = channelview(pimg)
     data = reshape(ch, :, *(size(pimg)...))
-    fuzzy_cmeans(data, rest...; debug = debug)
+    fuzzy_cmeans(data, args...; kwargs...)
 end

--- a/src/fuzzy_cmeans.jl
+++ b/src/fuzzy_cmeans.jl
@@ -1,61 +1,66 @@
-function update_weights!(weights, data, centers, fuzziness, norm_fn)
-  pow = 2.0/(fuzziness-1)
-  ly, lx = length.(indices(weights))
-  for i in 1:ly
-    vali = data[:,i]
-    for j in 1:lx
-      den = 0.0
-      for k in 1:lx
-        den += (norm_fn(vali-centers[:,j])/norm_fn(vali-centers[:,k]))^pow
-      end
-      weights[i,j] = 1.0/den
+function update_weights!(weights, data, centers, fuzziness, dist_metric)
+    pow = 2.0/(fuzziness-1)
+    nrows, ncols = size(weights)
+    dists = pairwise(dist_metric, data, centers)
+    for i in 1:nrows
+        for j in 1:ncols
+            den = 0.0
+            for k in 1:ncols
+                den += (dists[i,j]/dists[i,k])^pow
+            end
+            weights[i,j] = 1.0/den
+        end
     end
-  end
 end
 
 function update_centers!(centers, data, weights, fuzziness)
-  ly, lx = length.(indices(weights))
-  for j in 1:lx
-    num = zero(data[:,1])
-    den = 0.0
-    for i in 1:ly
-      δm = weights[i,j]^fuzziness
-      num += δm * data[:,i]
-      den += δm
+    nrows, ncols = size(weights)
+    for j in 1:ncols
+        num = zeros(Float64, size(data[:,1]))
+        den = 0.0
+        for i in 1:nrows
+            δm = weights[i,j]^fuzziness
+            num += δm * data[:,i]
+            den += δm
+        end
+        centers[:,j] = num/den
     end
-    centers[:,j] = num/den
-  end
 end
 
-function fuzzy_cmeans(data::AbstractArray{T,2}, C::Int, totiter::Int, eps_::Real, fuzziness::Real, norm_fn::Function = norm) where T<:Real
-  ly, lx = length.(indices(data))
+function fuzzy_cmeans(data::AbstractArray{T,2}, C::Int, fuzziness::Real, totiter::Int = 100, eps_::Real = 1e-3, dist_metric::Metric = Euclidean(); debug::Bool = false) where T<:Real
+    nrows, ncols = size(data)
 
-  weights = rand(Float64, (lx, C))
-  for i in 1:lx
-    s = sum(weights[i,:])
-    weights[i,:] /= s
-  end
+    # Initialize weights randomly
+    weights = rand(Float64, ncols, C)
+    weights ./= sum(weights, 2)
 
-  centers = fill(0.0, ly, C)
+    centers = fill(0.0, nrows, C)
 
-  δ = Inf
-  iter = 0
-  prev_centers = identity.(centers)
+    δ = Inf
+    iter = 0
+    prev_centers = identity.(centers)
 
-  while iter < totiter && δ > eps_
-    update_centers!(centers, data, weights, fuzziness)
-    update_weights!(weights, data, centers, fuzziness, norm_fn)
-    δ = maximum([norm_fn(prev_centers[:,i] - centers[:,i]) for i in 1:C])
-    copy!(prev_centers, centers)
-    iter += 1
-    println(iter,": ",δ)
-  end
+    if debug
+        prog = ProgressThresh(eps_, "Converging:")
+    end
 
-  weights, centers
+    while iter < totiter && δ > eps_
+        update_centers!(centers, data, weights, fuzziness)
+        update_weights!(weights, data, centers, fuzziness, dist_metric)
+        δ = maximum(colwise(dist_metric, prev_centers, centers))
+        copy!(prev_centers, centers)
+        iter += 1
+        if debug
+            ProgressMeter.update!(prog, δ, showvalues = [(:Iteration, iter)])
+        end
+    end
+
+    weights, centers
 end
 
-function fuzzy_cmeans(img::AbstractArray{T,N}, rest...) where T<:Colorant where N
-  ch = channelview(img)
-  data = reshape(ch, :, *(length.(indices(img))...))
-  fuzzy_cmeans(data, rest...)
+function fuzzy_cmeans(img::AbstractArray{T,N}, rest...; debug::Bool = false) where T<:Colorant where N
+    pimg = parent(img)
+    ch = channelview(pimg)
+    data = reshape(ch, :, *(size(pimg)...))
+    fuzzy_cmeans(data, rest...; debug = debug)
 end


### PR DESCRIPTION
An implementation of the standard fuzzy c-means algorithm as stated in [this paper](http://yaikhom.com/res/fcm/fcm.pdf). This implementation requires input to be of a similar form as that required by k-means in `Clustering.jl`. A wrapper has been written for images and works for general N-dimensional offset images. The output is a tuple of membership weights and segment centers. Tests and doc will be added soon.

Demo:
Original image:
![org](https://user-images.githubusercontent.com/15063205/29327447-c4106dfa-820c-11e7-85a5-7b07187ee412.png)

Applying fuzzy cmeans on image with C = 4, eps_ = 0.001 and fuzziness = 1.8
![c1](https://user-images.githubusercontent.com/15063205/29327842-238df6ca-820e-11e7-82ba-bb109ecbe143.png)
![c2](https://user-images.githubusercontent.com/15063205/29327839-2387d024-820e-11e7-92a2-7e1ea4ef5d34.png)
![c3](https://user-images.githubusercontent.com/15063205/29327841-238ccbd8-820e-11e7-8885-9a84380b1aa5.png)
![c4](https://user-images.githubusercontent.com/15063205/29327840-238b03f2-820e-11e7-903a-844124fd5196.png)

Original:
![so](https://user-images.githubusercontent.com/15063205/29328005-a62b0c58-820e-11e7-9c4d-7b42a8201cb6.png)

Applying fuzzy cmeans with C = 4, eps_ = 0.002 and fuzziness = 1.8
![si](https://user-images.githubusercontent.com/15063205/29328054-c5ba6d3e-820e-11e7-9684-53e47811cb37.png)


