### PR TITLE
Added method for constructing RAG from image

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -282,8 +282,8 @@ Any graph clustering technique can be used with the constructed RAG to segment t
 """
 
 function region_adjacency_graph(img::AbstractArray{CT,N}, weight_fn::Function, r::Int) where {CT<:Union{Colorant,Real}, N}
-    cartesian2node = LinearIndices(img)
-    node2cartesian = CartesianIndices(img)
+    cartesian2vertex = LinearIndices(img)
+    vertex2cartesian = CartesianIndices(img)
 
     sources = Vector{Int}()
     destinationss = Vector{Int}()
@@ -297,13 +297,13 @@ function region_adjacency_graph(img::AbstractArray{CT,N}, weight_fn::Function, r
             if I <= J 
                 continue
             end
-            append!(sources, cartesian2node[I])
-            append!(destinationss, cartesian2node[J])
+            append!(sources, cartesian2vertex[I])
+            append!(destinationss, cartesian2vertex[J])
             append!(weights, weight_fn(I, img[I], J, img[J]))
         end
     end
 
     G = SimpleWeightedGraph(sources, destinationss, weights)
 
-    return G, node2cartesian
+    return G, vertex2cartesian
 end

--- a/test/core.jl
+++ b/test/core.jl
@@ -121,7 +121,7 @@
   img = fill(1.0, (10,10))
   img[4:6, 4:6] .= 0
 
-  weight_fn(I::CartesianIndex{2}, img_I, J::CartesianIndex{2}, img_J) = exp(-abs(img_I - img_J)) / ((I[1]-J[1])^2 + (I[2]-J[2])^2) 
+  weight_fn(I, J) = exp(-abs(I.second - J.second)) / ((I.first[1]-J.first[1])^2 + (I.first[2]-J.first[2])^2)
   G, vertex2cartesian = region_adjacency_graph(img, weight_fn, 2)
 
   @test nv(G) == 100
@@ -129,9 +129,15 @@
   @test G.weights[43,44] == exp(-1)
 
   #test that all edges weights equal weights computed using weight_fn
-  @test all(map(edge-> edge.weight == weight_fn(vertex2cartesian[edge.src], img[vertex2cartesian[edge.src]], vertex2cartesian[edge.dst], img[vertex2cartesian[edge.dst]]), edges(G)))
+  @test all(map(edge-> edge.weight == weight_fn(vertex2cartesian[edge.src]=>img[vertex2cartesian[edge.src]], vertex2cartesian[edge.dst]=>img[vertex2cartesian[edge.dst]]), edges(G)))
 
   #test that all edges are between nodes less than r pixels away
   @test all(map(edge-> max(abs(vertex2cartesian[edge.src][1] - vertex2cartesian[edge.dst][1]), abs(vertex2cartesian[edge.src][2] - vertex2cartesian[edge.dst][2])) <= 2 , edges(G)))
+
+  @test region_adjacency_graph(img, weight_fn, 2) == region_adjacency_graph(img, weight_fn, CartesianIndex(2,2))
+
+  G, vertex2cartesian = region_adjacency_graph(img, weight_fn, CartesianIndex(1,2))
+  @test G.weights[45,47] == 0
+  @test G.weights[45,65] != 0
 
 end


### PR DESCRIPTION
Added a method for constructing region adjacency graph from an image. This RAG can be partitioned by any graph clustering method to segment the image.

I am unsure whether the documentation clearly explains how to use the function. @timholy Can you have a look?