### PR TITLE
Update to ImageCore 0.9

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ version = "1.5.1"
 
 [deps]
 Clustering = "aaaa29a8-35af-508c-8bc3-b662a17a0fe5"
-ColorVectorSpace = "c3611d14-8923-5661-9e6a-0046d554d3a4"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
@@ -20,12 +19,11 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 Clustering = "0.10, 0.11, 0.12, 0.13, 0.14"
-ColorVectorSpace = "0.7, 0.8"
 DataStructures = "0.17.11, 0.18"
 Distances = "0.8, 0.9.2, 0.10"
 Documenter = "0.24, 0.25"
-ImageCore = "0.8.6"
-ImageFiltering = "0.6"
+ImageCore = "0.9"
+ImageFiltering = "0.6, 0.7"
 ImageMorphology = "0.2.6"
 LightGraphs = "1.1"
 MetaGraphs = "0.6.6"
@@ -38,9 +36,8 @@ julia = "1"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
-Images = "916415d5-f1e6-5110-898d-aaa5f9f070e0"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Documenter", "FileIO", "ImageMagick", "Images", "SparseArrays", "Test"]
+test = ["Documenter", "FileIO", "ImageMagick", "SparseArrays", "Test"]

--- a/src/ImageSegmentation.jl
+++ b/src/ImageSegmentation.jl
@@ -4,6 +4,7 @@ import Base: show
 
 using LinearAlgebra, Statistics
 using DataStructures, StaticArrays, ImageCore, ImageFiltering, ImageMorphology, LightGraphs, SimpleWeightedGraphs, RegionTrees, Distances, StaticArrays, Clustering, MetaGraphs
+using ImageCore.ColorVectorSpace: MathTypes
 import Clustering: kmeans, fuzzy_cmeans
 
 const PairOrTuple{K,V} = Union{Pair{K,V},Tuple{K,V}}

--- a/src/core.jl
+++ b/src/core.jl
@@ -4,6 +4,14 @@ accum_type(::Type{T}) where {T<:Real}       = Float64
 accum_type(::Type{T}) where {T<:FixedPoint} = floattype(T)
 accum_type(::Type{C}) where {C<:Colorant}   = base_colorant_type(C){accum_type(eltype(C))}
 
+accum_type(val) = isa(val, Type) ? throw_accum_type(val) : convert(accum_type(typeof(val)), val)
+throw_accum_type(T) = error("type $T not supported in `accum_type`")
+
+_abs2(c::MathTypes) = c ⋅ c
+_abs2(x) = abs2(x)
+
+default_diff_fn(c1::CT1,c2::CT2) where {CT1<:Union{Colorant,Real}, CT2<:Union{Colorant,Real}} = sqrt(_abs2(c1-accum_type(c2)))
+
 """
 `SegmentedImage` type contains the index-label mapping, assigned labels,
 segment mean intensity and pixel count of each segment.

--- a/src/felzenszwalb.jl
+++ b/src/felzenszwalb.jl
@@ -102,7 +102,7 @@ function felzenszwalb(img::AbstractArray{T}, k::Real, min_size::Int = 0) where T
             if I >= J
                 continue
             end
-            edges[num+=1] = ImageEdge(L[I], L[J], sqrt(abs2(imgI-meantype(T)(img[J]))))
+            edges[num+=1] = ImageEdge(L[I], L[J], sqrt(_abs2(imgI-meantype(T)(img[J]))))
         end
     end
     deleteat!(edges, num+1:num_edges)   # compensate for the ones we were missing at the image edges

--- a/src/region_growing.jl
+++ b/src/region_growing.jl
@@ -1,7 +1,3 @@
-
-default_diff_fn(c1::CT1,c2::CT2) where {CT1<:Union{Colorant,Real}, CT2<:Union{Colorant,Real}} = sqrt(_abs2((c1)-accum_type(CT2)(c2)))
-_abs2(c) = mapreducec(v->float(v)^2, +, 0, c)/length(c)
-
 """
     seg_img = seeded_region_growing(img, seeds, [kernel_dim], [diff_fn])
     seg_img = seeded_region_growing(img, seeds, [neighbourhood], [diff_fn])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using ImageSegmentation, Images, Test, SimpleWeightedGraphs, LightGraphs, StaticArrays, DataStructures
+using ImageSegmentation, ImageCore, ImageFiltering, Test, SimpleWeightedGraphs, LightGraphs, StaticArrays, DataStructures
 using RegionTrees: isleaf, Cell, split!
 using MetaGraphs: MetaGraph, clear_props!, get_prop, has_prop, set_prop!, props, vertices
 

--- a/test/watershed.jl
+++ b/test/watershed.jl
@@ -4,8 +4,7 @@ using ImageFiltering
 
     img = zeros(100, 100)
     img[25:75, 25:75] .= 1
-
-    img, _ = magnitude_phase(img)
+    img[26:74, 26:74] .= 0
 
     markers = zeros(Int, size(img))
     markers[1, 1] = 1
@@ -45,7 +44,7 @@ using ImageFiltering
         # since this is using the compact algorithm with a high value for
         # compactness, the boundary between labels 1 and 2 should occur halfway
         # between the two markers
-        @test sum(labels .== 1) == sum(1:50) - 2
+        @test sum(labels .== 1) == sum(1:50)
     end
 
     @testset "h-minima transform" begin


### PR DESCRIPTION
This drops Images entirely, but doesn't pass tests. There are three issues, all in the watershed test:
- the use of `magnitude_phase`, which AFAICT is mostly to generate a box. I've prepared a substitute.
- perhaps as a consequence, the result of a test involving compact watersheds changed by a count of two pixels: now the first region is literally the upper-left triangle. Is this a bad change, @tlnagy?
- ~TODO: `findlocalminima` is still needed from Images. I'm tempted to move nearly *everything* out of Images and make it a pure meta-package. If people like that, I can think of two places, ImageBase and ImageFiltering. Thoughts?~

closes #71
