### PR TITLE
Add a warning for in-place `flood_fill!`

### DIFF
--- a/src/flood_fill.jl
+++ b/src/flood_fill.jl
@@ -62,6 +62,9 @@ The sense of connectivity is defined by `nbrhood_function`, with two choices bei
 [`ImageSegmentation.diamond_iterator`](@ref) and [`ImageSegmentation.box_iterator`](@ref.)
 
 You can optionally omit `dest`, in which case entries in `src` will be set to `fillvalue`.
+This is recommended only in cases where `fillvalue` is distinct from the values in `src`,
+as otherwise there is a risk that some voxels will be incorrectly identified as having been
+visited and their neighbors excluded from further search.
 You may also supply `isfilled`, which should return `true` for any value in `dest`
 which does not need to be set or visited; one requirement is that `isfilled(fillvalue) == true`.
 
@@ -117,6 +120,14 @@ flood_fill!(f, src::AbstractArray, idx::Union{Integer,CartesianIndex}, args...; 
 # This is a trivial implementation (just to get something working), better would be a raster implementation
 function _flood_fill!(f::F, dest, src, R::CartesianIndices{N}, q, nbrhood_function::FN, fillvalue, isfilled::C) where {F,N,FN,C}
     isfilled(fillvalue) == true || throw(ArgumentError("`isfilled(fillvalue)` must return `true`"))
+    if Base.mightalias(dest, src)
+        try
+            f(fillvalue) && @warn """
+                in-place `fillvalue` may not be distinct from array values, and filling may be incomplete.
+                To suppress this warning, avoid filling in-place or ensure `f(fillvalue)` is `false`."""
+        catch
+        end
+    end
     while !isempty(q)
         idx = pop!(q)
         dest[idx] = fillvalue

--- a/test/flood_fill.jl
+++ b/test/flood_fill.jl
@@ -72,13 +72,21 @@ using Test
     dest = fill!(similar(a, Bool), false)
     @test flood_fill!(near3, dest, a, idx) == (round.(a) .== 3)
     a = copy(a0)
-    flood_fill!(near3, a, idx; fillvalue=3)
-    @test a == [near3(a0[i]) ? 3 : a[i] for i in eachindex(a)]
-    a = copy(a0)
     flood_fill!(near3, a, idx; fillvalue=-1)
     @test a == [near3(a0[i]) ? -1 : a[i] for i in eachindex(a)]
     a = copy(a0)
     @test_throws ArgumentError flood_fill!(near3, a, idx; fillvalue=-1, isfilled=near3)
+    # warning
+    a = [1:7;]
+    @test_logs (:warn, r"distinct.*incomplete") flood_fill!(<(5), a, 1; fillvalue=3)
+    @test a == [3,3,3,4,5,6,7]
+    a = [1:7;]
+    dest = fill(-1, size(a))
+    @test_logs flood_fill!(<(5), dest, a, 1; fillvalue=3)   # no warnings
+    @test dest == [3,3,3,3,-1,-1,-1]
+    a = [1:7;]
+    @test_logs flood_fill!(<(5), a, 1; fillvalue=11)
+    @test a == [11,11,11,11,5,6,7]
 
     # This mimics a "big data" application in which we have several structures we want
     # to label with different segment numbers, and the `src` array is too big to fit


### PR DESCRIPTION
In-place fills have a risk of being incomplete if there is any chance
that the `fillval` is already present in `src`. This conservatively
adds a warning. There may be cases where this warning isn't needed, if
the user has special knowledge that the values are actually distinct.
But if so, it doesn't seem unreasonable to encourage the user to
exclude them from `f`.

This deletes one previous test, because the fact that it works is very
particular (it depends on starting at the one-and-only connected entry
with value `fillvalue`).  The new warning gets triggered in that
former test, and that's probably a good thing.