### PR TITLE
Fix #87 failing test

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -34,10 +34,11 @@ julia = "1"
 
 [extras]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Documenter", "FileIO", "ImageMagick", "SparseArrays", "Test"]
+test = ["Documenter", "Downloads", "FileIO", "ImageMagick", "SparseArrays", "Test"]

--- a/src/core.jl
+++ b/src/core.jl
@@ -284,15 +284,11 @@ end
 Return a function that constructs a box-shaped iterable region.
 
 # Examples
-```jldoctest; setup=:(using ImageSegmentation), filter=r"#\\d+"
-julia> fiter = ImageSegmentation.box_iterator((3, 3))
-#17 (generic function with 1 method)
-
-julia> center = CartesianIndex(17, 24)
-CartesianIndex(17, 24)
-
-julia> fiter(center)
-CartesianIndices((16:18, 23:25))
+```@repl
+using ImageSegmentation # hide
+fiter = ImageSegmentation.box_iterator((3, 3))
+center = CartesianIndex(17, 24)
+fiter(center)
 ```
 """
 function box_iterator(window::Dims{N}) where N

--- a/src/core.jl
+++ b/src/core.jl
@@ -292,10 +292,7 @@ julia> center = CartesianIndex(17, 24)
 CartesianIndex(17, 24)
 
 julia> fiter(center)
-3×3 CartesianIndices{2, Tuple{UnitRange{$Int}, UnitRange{$Int}}}:
- CartesianIndex(16, 23)  CartesianIndex(16, 24)  CartesianIndex(16, 25)
- CartesianIndex(17, 23)  CartesianIndex(17, 24)  CartesianIndex(17, 25)
- CartesianIndex(18, 23)  CartesianIndex(18, 24)  CartesianIndex(18, 25)
+CartesianIndices((16:18, 23:25))
 ```
 """
 function box_iterator(window::Dims{N}) where N

--- a/test/core.jl
+++ b/test/core.jl
@@ -140,4 +140,11 @@
   @test G.weights[45,47] == 0
   @test G.weights[45,65] != 0
 
+  #test box_iterator
+  fiter = ImageSegmentation.box_iterator((3, 3))
+  center = CartesianIndex(17, 24)
+  @test isa(fiter(center), CartesianIndices)
+  @test minimum(fiter(center)) == CartesianIndex(16, 23)
+  @test maximum(fiter(center)) == CartesianIndex(18, 25)
+
 end

--- a/test/flood_fill.jl
+++ b/test/flood_fill.jl
@@ -5,6 +5,7 @@ using FileIO
 using Statistics
 using SparseArrays
 using Test
+using Downloads
 
 @testset "flood_fill" begin
     # 0d
@@ -54,7 +55,7 @@ using Test
         end
     end
     # Colors
-    path = download("https://github.com/JuliaImages/juliaimages.github.io/raw/source/docs/src/pkgs/segmentation/assets/flower.jpg")
+    path = Downloads.download("https://github.com/JuliaImages/juliaimages.github.io/raw/source/docs/src/pkgs/segmentation/assets/flower.jpg")
     img = load(path)
     seg = flood(img, CartesianIndex(87,280); thresh=0.3*sqrt(3))   # TODO: eliminate the sqrt(3) when we transition to `abs2(c) = c ⋅ c`
     @test 0.2*length(seg) <= sum(seg) <= 0.25*length(seg)


### PR DESCRIPTION
- Fixes failling doctest #87 
- Replaces deprecated use of `Base.download` by using `Downloads.download` in `flood_fill` test to avoid a warning.