### PR TITLE
[compat] ImageCore 0.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ImageSegmentation"
 uuid = "80713f31-8817-5129-9cf8-209ff8fb23e1"
-version = "1.8.1"
+version = "1.8.2"
 
 [deps]
 Clustering = "aaaa29a8-35af-508c-8bc3-b662a17a0fe5"
@@ -23,7 +23,7 @@ DataStructures = "0.17.11, 0.18"
 Distances = "0.8, 0.9.2, 0.10"
 Documenter = "0.24, 0.25"
 Graphs = "1.4.1"
-ImageCore = "0.9"
+ImageCore = "0.10"
 ImageFiltering = "0.6, 0.7"
 ImageMorphology = "0.2.6, 0.3, 0.4"
 MetaGraphs = "0.7"

--- a/src/core.jl
+++ b/src/core.jl
@@ -7,12 +7,7 @@ accum_type(::Type{C}) where {C<:Colorant}   = base_colorant_type(C){accum_type(e
 accum_type(val) = isa(val, Type) ? throw_accum_type(val) : convert(accum_type(typeof(val)), val)
 throw_accum_type(T) = error("type $T not supported in `accum_type`")
 
-# TODO:
-# _abs2(c::MathTypes) = c ⋅ c
-_abs2(c::MathTypes) = mapreducec(v->float(v)^2, +, 0, c)
-_abs2(x) = abs2(x)
-
-default_diff_fn(c1::CT1,c2::CT2) where {CT1<:Union{Colorant,Real}, CT2<:Union{Colorant,Real}} = sqrt(_abs2(c1-accum_type(c2)))
+default_diff_fn(c1::CT1,c2::CT2) where {CT1<:Union{Colorant,Real}, CT2<:Union{Colorant,Real}} = sqrt(abs2(c1-accum_type(c2)))
 
 """
 `SegmentedImage` type contains the index-label mapping, assigned labels,

--- a/src/felzenszwalb.jl
+++ b/src/felzenszwalb.jl
@@ -102,7 +102,7 @@ function felzenszwalb(img::AbstractArray{T}, k::Real, min_size::Int = 0) where T
             if I >= J
                 continue
             end
-            edges[num+=1] = ImageEdge(L[I], L[J], sqrt(_abs2(imgI-meantype(T)(img[J]))))
+            edges[num+=1] = ImageEdge(L[I], L[J], sqrt(abs2(imgI-meantype(T)(img[J]))))
         end
     end
     deleteat!(edges, num+1:num_edges)   # compensate for the ones we were missing at the image edges

--- a/test/flood_fill.jl
+++ b/test/flood_fill.jl
@@ -56,7 +56,7 @@ using Test
     # Colors
     path = download("https://github.com/JuliaImages/juliaimages.github.io/raw/source/docs/src/pkgs/segmentation/assets/flower.jpg")
     img = load(path)
-    seg = flood(img, CartesianIndex(87,280); thresh=0.3*sqrt(3))   # TODO: eliminate the sqrt(3) when we transition to `abs2(c) = c ⋅ c`
+    seg = flood(img, CartesianIndex(87,280); thresh=0.3)
     @test 0.2*length(seg) <= sum(seg) <= 0.25*length(seg)
     c = mean(img[seg])
     # N0f8 makes for easier approximate testing


### PR DESCRIPTION
This also yanks out the old `abs2` deprecation in favor of using
the new implementation in ColorVectorSpace.