### PR TITLE
Don't accept NaN as a threshold for unseeded_region_growing

### DIFF
--- a/src/region_growing.jl
+++ b/src/region_growing.jl
@@ -238,6 +238,7 @@ function unseeded_region_growing(img::AbstractArray{CT,N}, threshold::Real,
 end
 
 function unseeded_region_growing(img::AbstractArray{CT,N}, threshold::Real, neighbourhood::Function, diff_fn::Function = default_diff_fn) where {CT<:Colorant,N}
+    @assert !isnan(threshold) "The threshold can't be a NaN value, it'll result in an instance per pixel"
     TM = meantype(CT)
 
     # Fast linear<->cartesian indexing lookup

--- a/src/region_growing.jl
+++ b/src/region_growing.jl
@@ -238,7 +238,7 @@ function unseeded_region_growing(img::AbstractArray{CT,N}, threshold::Real,
 end
 
 function unseeded_region_growing(img::AbstractArray{CT,N}, threshold::Real, neighbourhood::Function, diff_fn::Function = default_diff_fn) where {CT<:Colorant,N}
-    @assert !isnan(threshold) "The threshold can't be a NaN value, it'll result in an instance per pixel"
+    isnan(threshold) && throw(ArgumentError("The threshold can't be a NaN value, it'll result in an instance per pixel"))
     TM = meantype(CT)
 
     # Fast linear<->cartesian indexing lookup


### PR DESCRIPTION
Since `<` and `>` always return False with a NaN value, if a NaN is passed as a `threshold`, it'll result in a segmentation where each pixel is its own instance. 

I don't think that feature can be useful to someone, moreover, the algorithm can take ages with a medium size image when we have that increasing number of segments to check for. 