### PR TITLE
Construct from label map

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ImageSegmentation"
 uuid = "80713f31-8817-5129-9cf8-209ff8fb23e1"
-version = "1.8.4"
+version = "1.9.0"
 
 [deps]
 Clustering = "aaaa29a8-35af-508c-8bc3-b662a17a0fe5"


### PR DESCRIPTION
This adds a new constructor for `SegmentedImage`, allowing you to build
a `SegmentedImage` directly from a label map. This is useful for
algorithms, like `unseeded_region_growing`, that do not insist on
contiguous labels.